### PR TITLE
Add Repository URL in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "https://github.com/graphcool/chromeless.git"
   },
+  "bug": {
+    "url": "https://github.com/graphcool/chromeless/issues"
+  }, 
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "chromeless",
   "version": "1.0.1",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/graphcool/chromeless.git"
+  },
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
   "files": [


### PR DESCRIPTION
Thanks for nice library. I couldn't found repository link in [npm](https://www.npmjs.com/package/chromeless). So I add repository URL in `package.json`. :)