### PR TITLE
pdf() API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `mousedown(selector: string): Chromeless<T>` and `mouseup(selector: string): Chromeless<T>` APIs [#118](https://github.com/graphcool/chromeless/pull/118) @criticalbh
 - `focus(selector: string)` API [#132](https://github.com/graphcool/chromeless/pull/132) @criticalbh
 - When using chromeless locally, chromeless will now boot chrome automatically [#120](https://github.com/graphcool/chromeless/pull/120) @joelgriffith
+- `pdf()` API [#84](https://github.com/graphcool/chromeless/pull/84)
 
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ const chromeless = new Chromeless({
 - [`inputValue(selector: string)`](docs/api.md#api-inputvalue)
 - [`exists(selector: string)`](docs/api.md#api-exists)
 - [`screenshot()`](docs/api.md#api-screenshot)
-- [`pdf()`](docs/api.md#api-pdf) - Not implemented yet
+- [`pdf(options?: object)`](docs/api.md#api-pdf)
 - [`getHtml()`](docs/api.md#api-gethtml)
 - [`cookiesGet()`](docs/api.md#api-cookiesget)
 - [`cookiesGet(name: string)`](docs/api.md#api-cookiesget-name)

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ const chromeless = new Chromeless({
 - [`inputValue(selector: string)`](docs/api.md#api-inputvalue)
 - [`exists(selector: string)`](docs/api.md#api-exists)
 - [`screenshot()`](docs/api.md#api-screenshot)
-- [`pdf(options?: object)`](docs/api.md#api-pdf)
+- [`pdf(options?: PdfOptions)`](docs/api.md#api-pdf)
 - [`getHtml()`](docs/api.md#api-gethtml)
 - [`cookiesGet()`](docs/api.md#api-cookiesget)
 - [`cookiesGet(name: string)`](docs/api.md#api-cookiesget-name)

--- a/docs/api.md
+++ b/docs/api.md
@@ -399,7 +399,7 @@ When run over the Chromeless Proxy service, a URL to the PDF on S3 is returned.
 __Example__
 
 ```js
-const screenshot = await chromeless
+const pdf = await chromeless
   .goto('https://google.com/')
   .pdf()
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,7 +26,7 @@ Chromeless provides TypeScript typings.
 - [`inputValue(selector: string)`](#api-inputvalue)
 - [`exists(selector: string)`](#api-exists)
 - [`screenshot()`](#api-screenshot)
-- [`pdf(options?: object)`](#api-pdf)
+- [`pdf(options?: PdfOptions)`](#api-pdf)
 - [`getHtml()`](#api-gethtml)
 - [`cookiesGet()`](#api-cookiesget)
 - [`cookiesGet(name: string)`](#api-cookiesget-name)
@@ -390,7 +390,7 @@ console.log(screenshot) // prints local file path or S3 URL
 
 <a name="api-pdf" />
 
-### pdf(options?: object) - Chromeless<string>
+### pdf(options?: PdfOptions) - Chromeless<string>
 
 Print to a PDF of the document as framed by the viewport.
 When running Chromeless locally this returns the local file path to the PDF.

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,7 +26,7 @@ Chromeless provides TypeScript typings.
 - [`inputValue(selector: string)`](#api-inputvalue)
 - [`exists(selector: string)`](#api-exists)
 - [`screenshot()`](#api-screenshot)
-- [`pdf()`](#api-pdf) - Not implemented yet
+- [`pdf()`](#api-pdf)
 - [`getHtml()`](#api-gethtml)
 - [`cookiesGet()`](#api-cookiesget)
 - [`cookiesGet(name: string)`](#api-cookiesget-name)
@@ -390,9 +390,21 @@ console.log(screenshot) // prints local file path or S3 URL
 
 <a name="api-pdf" />
 
-### pdf() - Not implemented yet
+### pdf() - Chromeless<string>
 
-Not implemented yet
+Print to a PDF of the document as framed by the viewport.
+When running Chromeless locally this returns the local file path to the PDF.
+When run over the Chromeless Proxy service, a URL to the PDF on S3 is returned.
+
+__Example__
+
+```js
+const screenshot = await chromeless
+  .goto('https://google.com/')
+  .pdf()
+
+console.log(pdf) // prints local file path or S3 URL
+```
 
 ---------------------------------------
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,7 +26,7 @@ Chromeless provides TypeScript typings.
 - [`inputValue(selector: string)`](#api-inputvalue)
 - [`exists(selector: string)`](#api-exists)
 - [`screenshot()`](#api-screenshot)
-- [`pdf()`](#api-pdf)
+- [`pdf(options?: object)`](#api-pdf)
 - [`getHtml()`](#api-gethtml)
 - [`cookiesGet()`](#api-cookiesget)
 - [`cookiesGet(name: string)`](#api-cookiesget-name)
@@ -390,18 +390,21 @@ console.log(screenshot) // prints local file path or S3 URL
 
 <a name="api-pdf" />
 
-### pdf() - Chromeless<string>
+### pdf(options?: object) - Chromeless<string>
 
 Print to a PDF of the document as framed by the viewport.
 When running Chromeless locally this returns the local file path to the PDF.
 When run over the Chromeless Proxy service, a URL to the PDF on S3 is returned.
+
+__Arguments__
+- `options` - An object containing overrides for [printToPDF() parameters](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF)
 
 __Example__
 
 ```js
 const pdf = await chromeless
   .goto('https://google.com/')
-  .pdf()
+  .pdf({landscape: true})
 
 console.log(pdf) // prints local file path or S3 URL
 ```

--- a/src/api.ts
+++ b/src/api.ts
@@ -186,6 +186,12 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return new Chromeless<string>({}, this)
   }
 
+  pdf(): Chromeless<string> {
+    this.lastReturnPromise = this.queue.process<string>({type: 'returnPDF'})
+
+    return new Chromeless<string>({}, this)
+  }
+
   /**
    * Get the cookies for the current url
    */

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,7 @@
 import ChromeLocal from './chrome/local'
 import ChromeRemote from './chrome/remote'
 import Queue from './queue'
-import { ChromelessOptions, Cookie, CookieQuery } from './types'
+import { ChromelessOptions, Cookie, CookieQuery, PdfOptions } from './types'
 import { getDebugOption } from './util'
 
 export default class Chromeless<T extends any> implements Promise<T> {
@@ -186,7 +186,7 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return new Chromeless<string>({}, this)
   }
 
-  pdf(options = {}): Chromeless<string> {
+  pdf(options?: PdfOptions): Chromeless<string> {
     this.lastReturnPromise = this.queue.process<string>({type: 'returnPDF', options})
 
     return new Chromeless<string>({}, this)

--- a/src/api.ts
+++ b/src/api.ts
@@ -186,8 +186,8 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return new Chromeless<string>({}, this)
   }
 
-  pdf(): Chromeless<string> {
-    this.lastReturnPromise = this.queue.process<string>({type: 'returnPDF'})
+  pdf(options = {}): Chromeless<string> {
+    this.lastReturnPromise = this.queue.process<string>({type: 'returnPDF', options})
 
     return new Chromeless<string>({}, this)
   }

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -55,7 +55,7 @@ export default class LocalRuntime {
       case 'returnHtml':
         return this.returnHtml()
       case 'returnPDF':
-        return this.returnPDF()
+        return this.returnPDF(command.options)
       case 'returnInputValue':
         return this.returnInputValue(command.selector)
       case 'type':
@@ -279,8 +279,8 @@ export default class LocalRuntime {
   }
 
   // Returns the S3 url or local file path
-  async returnPDF(): Promise<string> {
-    const data = await pdf(this.client)
+  async returnPDF(options: object): Promise<string> {
+    const data = await pdf(this.client, options)
 
     // check if S3 configured
     if (process.env['CHROMELESS_S3_BUCKET_NAME'] && process.env['CHROMELESS_S3_BUCKET_URL']) {

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -10,6 +10,7 @@ import {
   evaluate,
   screenshot,
   getHtml,
+  pdf,
   type,
   getValue,
   scrollTo,
@@ -53,6 +54,8 @@ export default class LocalRuntime {
         return this.returnScreenshot()
       case 'returnHtml':
         return this.returnHtml()
+      case 'returnPDF':
+        return this.returnPDF()
       case 'returnInputValue':
         return this.returnInputValue(command.selector)
       case 'type':
@@ -273,6 +276,34 @@ export default class LocalRuntime {
 
   async returnHtml(): Promise<string> {
     return await getHtml(this.client)
+  }
+
+  // Returns the S3 url or local file path
+  async returnPDF(): Promise<string> {
+    const data = await pdf(this.client)
+
+    // check if S3 configured
+    if (process.env['CHROMELESS_S3_BUCKET_NAME'] && process.env['CHROMELESS_S3_BUCKET_URL']) {
+      const s3Path = `${cuid()}.pdf`
+      const s3 = new AWS.S3()
+      await s3.putObject({
+        Bucket: process.env['CHROMELESS_S3_BUCKET_NAME'],
+        Key: s3Path,
+        ContentType: 'application/pdf',
+        ACL: 'public-read',
+        Body: new Buffer(data, 'base64'),
+      }).promise()
+
+      return `https://${process.env['CHROMELESS_S3_BUCKET_URL']}/${s3Path}`
+    }
+
+    // write to `/tmp` instead
+    else {
+      const filePath = `/tmp/${cuid()}.pdf`
+      fs.writeFileSync(filePath, Buffer.from(data, 'base64'))
+
+      return filePath
+    }
   }
 
   private log(msg: string): void {

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -1,5 +1,5 @@
 import * as AWS from 'aws-sdk'
-import { Client, Command, ChromelessOptions, Cookie, CookieQuery } from '../types'
+import { Client, Command, ChromelessOptions, Cookie, CookieQuery, PdfOptions } from '../types'
 import * as cuid from 'cuid'
 import * as fs from 'fs'
 import {
@@ -279,7 +279,7 @@ export default class LocalRuntime {
   }
 
   // Returns the S3 url or local file path
-  async returnPDF(options: object): Promise<string> {
+  async returnPDF(options?: PdfOptions): Promise<string> {
     const data = await pdf(this.client, options)
 
     // check if S3 configured

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,9 @@ export type Command =
       type: 'returnHtml'
     }
   | {
+      type: 'returnPDF'
+    }
+  | {
       type: 'scrollTo'
       x: number
       y: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export type Command =
     }
   | {
       type: 'returnPDF',
-      options: object
+      options?: PdfOptions
     }
   | {
       type: 'scrollTo'
@@ -154,4 +154,20 @@ export interface CookieQuery {
   httpOnly?: boolean
   secure?: boolean
   session?: boolean
+}
+
+// https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF
+export interface PdfOptions {
+  landscape?: boolean,
+  displayHeaderFooter?: boolean,
+  printBackground?: boolean,
+  scale?: number,
+  paperWidth?: number,
+  paperHeight?: number,
+  marginTop?: number,
+  marginBottom?: number,
+  marginLeft?: number,
+  marginRight?: number,
+  pageRanges?: string,
+  ignoreInvalidPageRanges?: boolean
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,8 @@ export type Command =
       type: 'returnHtml'
     }
   | {
-      type: 'returnPDF'
+      type: 'returnPDF',
+      options: object
     }
   | {
       type: 'scrollTo'

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs'
 import * as path from 'path'
-import { Client, Cookie } from './types'
+import { Client, Cookie, PdfOptions } from './types'
 
 export const version: string = ((): string => {
   if (fs.existsSync(path.join(__dirname, '../package.json'))) {
@@ -332,7 +332,7 @@ export async function getHtml(client: Client): Promise<string> {
   return outerHTML
 }
 
-export async function pdf(client: Client, options: object): Promise<string> {
+export async function pdf(client: Client, options?: PdfOptions): Promise<string> {
   const {Page} = client
 
   const pdf = await Page.printToPDF(options)

--- a/src/util.ts
+++ b/src/util.ts
@@ -332,6 +332,14 @@ export async function getHtml(client: Client): Promise<string> {
   return outerHTML
 }
 
+export async function pdf(client: Client): Promise<string> {
+  const {Page} = client
+
+  const pdf = await Page.printToPDF()
+
+  return pdf.data
+}
+
 export function getDebugOption(): boolean {
   if (process && process.env && process.env['DEBUG'] && process.env['DEBUG'].includes('chromeless')) {
     return true

--- a/src/util.ts
+++ b/src/util.ts
@@ -332,10 +332,10 @@ export async function getHtml(client: Client): Promise<string> {
   return outerHTML
 }
 
-export async function pdf(client: Client): Promise<string> {
+export async function pdf(client: Client, options: object): Promise<string> {
   const {Page} = client
 
-  const pdf = await Page.printToPDF()
+  const pdf = await Page.printToPDF(options)
 
   return pdf.data
 }


### PR DESCRIPTION
`Page.printToPDF()` documentation:
https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF

You can test this the same way as the screenshot example:

```js
const { Chromeless } = require('chromeless')

async function run() {
  const chromeless = new Chromeless()

  const pdf = await chromeless
    .goto('https://www.google.com')
    .type('chromeless', 'input[name="q"]')
    .press(13)
    .wait('#resultStats')
    .pdf({landscape: true})

  console.log(pdf) // prints local file path or S3 url

  await chromeless.end()
}

run().catch(console.error.bind(console))
```