### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:8.2-alpine
+
+# Run tasks as unpriviledged user
+USER node
+
+# Change to $HOME as defined in node:8.2-alpine image
+WORKDIR /home/node
+
+# Install app dependencies
+RUN npm install chromeless
+
+ENTRYPOINT ["node"]
+CMD ["-h"]


### PR DESCRIPTION
Fix for https://github.com/graphcool/chromeless/issues/25 . I'm not really into NodeJS but know Docker quite well and I love this project. So that's my first try to contribute a little bit. :smiley: 

I first tried to use `package.json` and `npm install` during `docker build ...` but that ended in a linter error no matter if I used the Node Alpine image or the one which is based on Debian Jessie. So I stayed with the Alpine image as the final image is "only" 100 MB while the Jessie based is about 700 MB and Alpine works fine (used it successfully during testing some scripts). Here is the error I got using `package.json`:

```
> chromeless@1.0.1 tslint /home/node
> tslint -c tslint.json -p tsconfig.json

Invalid option for configuration: tslint.json
npm info lifecycle chromeless@1.0.1~tslint: Failed to exec tslint script
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! chromeless@1.0.1 tslint: `tslint -c tslint.json -p tsconfig.json`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the chromeless@1.0.1 tslint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/node/.npm/_logs/2017-07-29T20_13_32_610Z-debug.log
npm info lifecycle chromeless@1.0.1~test: Failed to exec test script
npm ERR! Test failed.  See above for more details.
npm info lifecycle chromeless@1.0.1~prepublish: Failed to exec prepublish script
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! chromeless@1.0.1 prepublish: `npm run build; npm test`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the chromeless@1.0.1 prepublish script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/node/.npm/_logs/2017-07-29T20_13_32_736Z-debug.log
The command '/bin/sh -c npm install' returned a non-zero code: 1
```

So I decided to just install `chromeless` package and that worked for me. After building the chromeless image with e.g `docker build -t chromeless-alpine:lastest .` you can start it like so:

```
docker run --rm --net=host -v yourscript.js:/home/node/yourscript.js chromeless-alpine:latest yourscript.js
```

If you started Chrome locally e.g. with `google-chrome --remote-debugging-port=9222` the option `--net=host` enables you to access `localhost:9222` on the host (where Chrome is listening). `-v yourscript.js:/home/node/yourscript.js` basically mounts a host local script you want to execute into $HOME of the node user inside the container (inherited from node Alpine image). And finally you pass `yourscript.js` as argument to the container. As the entrypoint is `node` it will pass `yourscript.js` as argument to `node` executable.

There is also already a Docker image for `chrome-headless`. Install with

```
docker pull knqz/chrome-headless
```

and start with

```
docker run -d -p 9222:9222 --rm --name chrome-headless knqz/chrome-headless
```

This also works with the same `docker run ...` command already mentioned above. 

Let me know if this is sufficient for you or what should be added or changed.