### PR TITLE
Change .evaluate to handle promises, docs, rimraf, prepublishOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ In case the deployment of the serverless function returns an error like this:
 ```
 Please check, that there is no stack with the name `chromeless-serverless-dev` existing yet, otherwise serverless can't correctly provision the bucket.
 
+### No command gets executed
+In order for the commands to be processed, make sure, that you call one of the commands `screenshot`, `evaluate`, `cookiesGetAll` or `end` at the end of your execution chain.
+
 ## Contributors
 
 A big thank you to all contributors and supporters of this repository 💚

--- a/docs/api.md
+++ b/docs/api.md
@@ -276,10 +276,10 @@ await chromeless.viewport(1024, 800)
 
 ### evaluate<U extends any>(fn: (...args: any[]) => void, ...args: any[]): Chromeless<U>
 
-Evaluate Javascript code within Chrome in the context of the DOM.
+Evaluate Javascript code within Chrome in the context of the DOM. Return the resulting value or a Promise.
 
 __Arguments__
-- `fn` - Function to evaluate within Chrome
+- `fn` - Function to evaluate within Chrome, can be async (Promise).
 - `[arguments]` - Arguments to pass to the function
 
 __Example__

--- a/docs/api.md
+++ b/docs/api.md
@@ -276,7 +276,7 @@ await chromeless.viewport(1024, 800)
 
 ### evaluate<U extends any>(fn: (...args: any[]) => void, ...args: any[]): Chromeless<U>
 
-Evaluate Javascript code within Chrome in the context of the DOM. Return the resulting value or a Promise.
+Evaluate Javascript code within Chrome in the context of the DOM. Returns the resulting value or a Promise.
 
 __Arguments__
 - `fn` - Function to evaluate within Chrome, can be async (Promise).

--- a/package.json
+++ b/package.json
@@ -13,14 +13,22 @@
   },
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
-  "files": ["dist"],
-  "engines": {
-    "node": ">= 6.10.0"
+  "files": [
+    "dist"
+  ],
+  "devDependencies": {
+    "@types/bluebird": "^3.5.8",
+    "@types/cuid": "^1.3.0",
+    "@types/node": "^8.0.15",
+    "ava": "^0.21.0",
+    "rimraf": "^2.6.1",
+    "tslint": "^5.5.0",
+    "typescript": "^2.4.2"
   },
   "scripts": {
     "watch": "tsc -w",
-    "build": "rm -rf dist; tsc -d",
-    "prepublish": "npm run build; npm test",
+    "build": "rimraf dist; tsc -d",
+    "prepublishOnly": "npm run build; npm test",
     "test": "npm run tslint",
     "tslint": "tslint -c tslint.json -p tsconfig.json"
   },

--- a/package.json
+++ b/package.json
@@ -1,8 +1,6 @@
 {
   "name": "chromeless",
   "version": "1.0.1",
-  "description": "🖥 Chrome automation made simple. Runs locally or headless on AWS Lambda.",
-  "homepage": "https://github.com/graphcool/chromeless",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -40,13 +38,5 @@
     "form-data": "^2.1.4",
     "got": "^7.1.0",
     "mqtt": "^2.9.2"
-  },
-  "devDependencies": {
-    "@types/bluebird": "^3.5.8",
-    "@types/cuid": "^1.3.0",
-    "@types/node": "^8.0.15",
-    "ava": "^0.21.0",
-    "tslint": "^5.5.0",
-    "typescript": "^2.4.2"
   }
 }

--- a/serverless/README.md
+++ b/serverless/README.md
@@ -17,8 +17,6 @@ cd chromeless/serverless
 npm install
 ```
 
-### Configure
-
 Next, modify the `custom` section in `serverless.yml`.
 
 You must set `awsIotHost` to the your AWS IoT Custom Endpoint for your AWS region. You can find this with the AWS CLI with `aws iot describe-endpoint --output text` or by navigating to the AWS IoT Console and going to Settings.
@@ -51,25 +49,6 @@ provider:
 ...
 ```
 
-### Credentials
-
-Before you can deploy, you must configure your AWS credentials either by defining `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environmental variables, or using an AWS profile. You can read more about this on the [Serverless Credentials Guide](https://serverless.com/framework/docs/providers/aws/guide/credentials/).
-
-In short, either:
-
-```bash
-export AWS_PROFILE=<your-profile-name>
-```
-
-or
-
-```bash
-export AWS_ACCESS_KEY_ID=<your-key-here>
-export AWS_SECRET_ACCESS_KEY=<your-secret-key-here>
-```
-
-### Deploy
-
 Once configured, deploying the service can be done with:
 
 ```bash
@@ -99,8 +78,7 @@ functions:
 
 ## Using the Proxy
 
-Connect to the proxy service with the `remote` option parameter on the Chromeless constructor. You must provide the endpoint URL provided during deployment either as an argument or set it in the `CHROMELESS_ENDPOINT_URL` environment variable. Note that this endpoint is _different_ from the AWS IoT Custom Endpoint. The Proxy's endpoint URL you want to use will look something like `https://XXXXXXXXXX.execute-api.eu-west-1.amazonaws.com/dev/`
-
+Connect to the proxy service with the `remote` option parameter on the Chromeless constructor. You must provide the endpoint URL provided during deployment either as an argument or set it in the `CHROMELESS_ENDPOINT_URL` environment variable. Note that this endpoint is _different_ from the AWS IoT Custom Endpoint.
 
 ### Option 1: Environment Variables
 

--- a/serverless/package.json
+++ b/serverless/package.json
@@ -1,12 +1,7 @@
 {
   "name": "chromeless-remotechrome-servie",
   "version": "1.0.0",
-  "description": "The Chromeless Proxy AWS Lambda service",
-  "homepage": "https://github.com/graphcool/chromeless",
   "license": "MIT",
-  "engines": {
-    "node": ">= 6.10.0"
-  },
   "scripts": {
     "deploy": "serverless deploy"
   },
@@ -18,8 +13,6 @@
     "source-map-support": "^0.4.15"
   },
   "devDependencies": {
-    "@types/cuid": "^1.3.0",
-    "@types/node": "^8.0.15",
     "serverless": "^1.18.0",
     "serverless-offline": "^3.15.1",
     "serverless-plugin-chrome": "^1.0.0-11",

--- a/serverless/src/run.ts
+++ b/serverless/src/run.ts
@@ -104,7 +104,7 @@ export default async (
 
           clearTimeout(timeout)
 
-          debug(`Mesage from ${TOPIC_REQUEST}`, message)
+          debug(`Message from ${TOPIC_REQUEST}`, message)
 
           const command = JSON.parse(message)
 
@@ -144,7 +144,7 @@ export default async (
           const message = buffer.toString()
           const data = JSON.parse(message)
 
-          debug(`Mesage from ${TOPIC_END}`, message)
+          debug(`Message from ${TOPIC_END}`, message)
           debug(
             `Client ${data.disconnected ? 'disconnected' : 'ended session'}.`
           )

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -165,7 +165,7 @@ export default class LocalRuntime {
 
   async press(keyCode: number, count?: number, modifiers?: any): Promise<void> {
     this.log(`Sending keyCode ${keyCode} (modifiers: ${modifiers})`)
-    await press(this.client, keyCode, count, this.chromlessOptions.viewport.scale, modifiers)
+    await press(this.client, keyCode, count, modifiers)
   }
 
   async returnExists(selector: string): Promise<boolean> {

--- a/src/chrome/remote.ts
+++ b/src/chrome/remote.ts
@@ -173,10 +173,10 @@ export default class RemoteChrome implements Chrome {
             }
           }
         })
+        this.channel.publish(this.TOPIC_REQUEST, JSON.stringify(command))
       })
     })
 
-    this.channel.publish(this.TOPIC_REQUEST, JSON.stringify(command))
 
     return promise
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -136,12 +136,14 @@ export async function evaluate<T>(client: Client, fn: string, ...args: any[]): P
   const argStr = jsonArgs.substr(1, jsonArgs.length - 2)
 
   const expression = `
-    const expressionResult = (${fn})(${argStr})
-    if (expressionResult && expressionResult.then) {
-      expressionResult.catch((error) => { throw new Error(error); });
-      return expressionResult;
-    }
-    return Promise.resolve(expressionResult);
+    (() => {
+      const expressionResult = (${fn})(${argStr});
+      if (expressionResult && expressionResult.then) {
+        expressionResult.catch((error) => { throw new Error(error); });
+        return expressionResult;
+      }
+      return Promise.resolve(expressionResult);
+    })();
   `
 
   const result = await Runtime.evaluate({

--- a/src/util.ts
+++ b/src/util.ts
@@ -161,13 +161,7 @@ export async function type(client: Client, text: string, selector?: string): Pro
   }
 }
 
-export async function press(client: Client, keyCode: number, scale: number, count?: number, modifiers?: any): Promise<void> {
-
-  // special handling for backspace
-  if (keyCode === 8) {
-    await backspace(client, scale, count || 1)
-    return
-  }
+export async function press(client: Client, keyCode: number, count?: number, modifiers?: any): Promise<void> {
 
   const {Input} = client
 
@@ -194,38 +188,6 @@ export async function press(client: Client, keyCode: number, scale: number, coun
       type: 'keyUp',
     })
   }
-}
-
-export async function backspace(client: Client, n: number, scale: number, selector?: string): Promise<void> {
-  if (selector) {
-    await click(client, selector, scale)
-    await wait(500)
-  }
-
-  const {Input} = client
-
-  for (let i = 0; i < n; i++) {
-    const options = {
-      modifiers: 8,
-      key: 'Backspace',
-      code: 'Backspace',
-      nativeVirtualKeyCode: 8,
-      windowsVirtualKeyCode: 8,
-    }
-    await Input.dispatchKeyEvent({
-      ...options,
-      type: 'rawKeyDown',
-    })
-    await Input.dispatchKeyEvent({
-      ...options,
-      type: 'keyUp',
-    })
-  }
-  const options = {
-    type: 'rawKeyDown',
-    nativeVirtualKeyCode: 46,
-  }
-  await Input.dispatchKeyEvent(options)
 }
 
 export async function getValue(client: Client, selector: string): Promise<string> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -134,12 +134,34 @@ export async function evaluate<T>(client: Client, fn: string, ...args: any[]): P
   const {Runtime} = client
   const jsonArgs = JSON.stringify(args)
   const argStr = jsonArgs.substr(1, jsonArgs.length - 2)
-  const expression = `(${fn})(${argStr})`
+
+  const expression = `
+    const expressionResult = (${fn})(${argStr})
+    if (expressionResult && expressionResult.then) {
+      expressionResult.catch((error) => { throw new Error(error); });
+      return expressionResult;
+    }
+    return Promise.resolve(expressionResult);
+  `
 
   const result = await Runtime.evaluate({
     expression,
+    returnByValue: true,
+    awaitPromise: true,
   })
-  return result.result.value
+
+  if (result && result.exceptionDetails) {
+    throw new Error(
+      result.exceptionDetails.exception.value ||
+      result.exceptionDetails.exception.description
+    );
+  }
+
+  if (result && result.result) {
+    return result.result.value
+  }
+
+  return null;
 }
 
 export async function type(client: Client, text: string, selector?: string): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,8 +53,8 @@
   resolved "https://registry.yarnpkg.com/@types/cuid/-/cuid-1.3.0.tgz#20b0e00ca555df564866bc52d2e251bf90c88db7"
 
 "@types/node@^8.0.15":
-  version "8.0.16"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.16.tgz#5aa51abd72621a0ce53fb86bccd76825ee1b4ca9"
+  version "8.0.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.17.tgz#677bc8c118cfb76013febb62ede1f31d2c7222a1"
 
 abbrev@1:
   version "1.1.0"
@@ -100,11 +100,11 @@ ansi-styles@~1.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
 
 anymatch@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
   dependencies:
-    arrify "^1.0.0"
     micromatch "^2.1.5"
+    normalize-path "^2.0.0"
 
 aproba@^1.0.3:
   version "1.1.2"
@@ -283,8 +283,8 @@ ava@^0.21.0:
     update-notifier "^2.1.0"
 
 aws-sdk@^2.90.0:
-  version "2.90.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.90.0.tgz#7dfe5c5ce2f2b7d33ef426692586f7d539919ea0"
+  version "2.92.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.92.0.tgz#46944fef0e2d7932a04ac3497cc4adc4467fae09"
   dependencies:
     buffer "4.9.1"
     crypto-browserify "1.0.9"
@@ -552,8 +552,8 @@ babel-register@^6.24.1:
     source-map-support "^0.4.2"
 
 babel-runtime@^6.22.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.25.0.tgz#33b98eaa5d482bb01a8d1aa6b437ad2b01aec41c"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
@@ -2153,7 +2153,7 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^2.0.1:
+normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
@@ -2660,8 +2660,8 @@ resolve-from@^3.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
 resolve@^1.3.2:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:
     path-parse "^1.0.5"
 
@@ -2681,10 +2681,6 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1:
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
-
-safe-buffer@~5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
 sax@1.2.1, sax@>=0.6.0:
   version "1.2.1"
@@ -3127,8 +3123,8 @@ verror@1.3.6:
     extsprintf "1.0.2"
 
 websocket-stream@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/websocket-stream/-/websocket-stream-5.0.0.tgz#1d1318f0576ce20a12555372108ae9418a403634"
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/websocket-stream/-/websocket-stream-5.0.1.tgz#51cb992988c2eeb4525ccd90eafbac52a5ac6700"
   dependencies:
     duplexify "^3.2.0"
     inherits "^2.0.1"
@@ -3204,10 +3200,10 @@ ws@2.0.x:
     ultron "~1.1.0"
 
 ws@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.0.0.tgz#98ddb00056c8390cb751e7788788497f99103b6c"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.1.0.tgz#8afafecdeab46d572e5397ee880739367aa2f41c"
   dependencies:
-    safe-buffer "~5.0.1"
+    safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
 xdg-basedir@^3.0.0:


### PR DESCRIPTION
- `#evaluate` can handle `Promise`'s, and unwraps results more gracefully (docs update there).
- Moving `rm -rf` in `build` to `rimraf` for our Windows friends. 
- I moved `prepublish` hook to `prepublishOnly`, didn't seem like we need it to run in `npm install`.