### PR TITLE
Fix README.md/api.md waitFn

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ const chromeless = new Chromeless({
 - [`click(selector: string)`](docs/api.md#api-click)
 - [`wait(timeout: number)`](docs/api.md#api-wait-timeout)
 - [`wait(selector: string)`](docs/api.md#api-wait-selector)
-- [`wait(fn: (...args: any[]) => boolean, ...args: any[])`](docs/api.md#api-wait-fn)
+- [`wait(fn: (...args: any[]) => boolean, ...args: any[])`] - Not implemented yet
 - [`focus(selector: string)`](docs/api.md#api-focus)
 - [`press(keyCode: number, count?: number, modifiers?: any)`](docs/api.md#api-press)
 - [`type(input: string, selector?: string)`](docs/api.md#api-type)

--- a/docs/api.md
+++ b/docs/api.md
@@ -124,6 +124,8 @@ await chromeless.wait('div#loaded')
 
 ### wait(fn: (...args: any[]) => boolean, ...args: any[]): Chromeless<T>
 
+Not implemented yet
+
 Wait until a function returns.
 
 __Arguments__

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,7 @@ Chromeless provides TypeScript typings.
 - [`click(selector: string)`](#api-click)
 - [`wait(timeout: number)`](#api-wait-timeout)
 - [`wait(selector: string)`](#api-wait-selector)
-- [`wait(fn: (...args: any[]) => boolean, ...args: any[])`](#api-wait-fn)
+- [`wait(fn: (...args: any[]) => boolean, ...args: any[])`] - Not implemented yet
 - [`focus(selector: string)`](#api-focus)
 - [`press(keyCode: number, count?: number, modifiers?: any)`](#api-press)
 - [`type(input: string, selector?: string)`](#api-type)


### PR DESCRIPTION
Despite the documentation says https://github.com/graphcool/chromeless/blob/master/docs/api.md#api-wait-fn is implemented it's actually not: https://github.com/graphcool/chromeless/blob/master/src/chrome/local-runtime.ts#L41 
This PR fixes the docs (despite that I hope to get it implemented soon :pray: ).