### PR TITLE
setHtml() and getHtml() API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - CODE_OF_CONDUCT.md, CONTRIBUTING.md
+- `getHtml()` and `setHtml()` APIs. [#112](https://github.com/graphcool/chromeless/pull/112), [#74](https://github.com/graphcool/chromeless/issues/74)
 
 ### Changed
 - `.evaluate()` now returns the resulting value or a Promise [#110](https://github.com/graphcool/chromeless/pull/110) @joelgriffith

--- a/README.md
+++ b/README.md
@@ -153,12 +153,14 @@ const chromeless = new Chromeless({
 - [`mousedown()`](docs/api.md#api-mousedown) - Not implemented yet
 - [`mouseup()`](docs/api.md#api-mouseup) - Not implemented yet
 - [`scrollTo(x: number, y: number)`](docs/api.md#api-scrollto)
+- [`setHtml(html: string)`](docs/api.md#api-sethtml)
 - [`viewport(width: number, height: number)`](docs/api.md#api-viewport)
 - [`evaluate<U extends any>(fn: (...args: any[]) => void, ...args: any[])`](docs/api.md#api-evaluate)
 - [`inputValue(selector: string)`](docs/api.md#api-inputvalue)
 - [`exists(selector: string)`](docs/api.md#api-exists)
 - [`screenshot()`](docs/api.md#api-screenshot)
 - [`pdf()`](docs/api.md#api-pdf) - Not implemented yet
+- [`getHtml()`](docs/api.md#api-gethtml)
 - [`cookiesGet()`](docs/api.md#api-cookiesget)
 - [`cookiesGet(name: string)`](docs/api.md#api-cookiesget-name)
 - [`cookiesGet(query: CookieQuery)`](docs/api.md#api-cookiesget-query) - Not implemented yet

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,7 @@ Chromeless provides TypeScript typings.
 - [`exists(selector: string)`](#api-exists)
 - [`screenshot()`](#api-screenshot)
 - [`pdf()`](#api-pdf) - Not implemented yet
+- [`getHtml()`](#api-gethtml)
 - [`cookiesGet()`](#api-cookiesget)
 - [`cookiesGet(name: string)`](#api-cookiesget-name)
 - [`cookiesGet(query: CookieQuery)`](#api-cookiesget-query) - Not implemented yet
@@ -374,6 +375,24 @@ console.log(screenshot) // prints local file path or S3 URL
 ### pdf() - Not implemented yet
 
 Not implemented yet
+
+---------------------------------------
+
+<a name="api-gethtml" />
+
+### getHtml(): Chromeless<string>
+
+Get full HTML of the loaded page.
+
+__Example__
+
+```js
+const html = await chromeless
+  .setHtml('<h1>Hello world!</h1>')
+  .getHtml()
+
+console.log(html) // <html><head></head><body><h1>Hello world!</h1></body></html>
+```
 
 ---------------------------------------
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,7 @@ Chromeless provides TypeScript typings.
 - [`mousedown()`](#api-mousedown) - Not implemented yet
 - [`mouseup()`](#api-mouseup) - Not implemented yet
 - [`scrollTo(x: number, y: number)`](#api-scrollto)
+- [`setDocumentContent(html: string)`](#api-setdocumentcontent)
 - [`viewport(width: number, height: number)`](#api-viewport)
 - [`evaluate<U extends any>(fn: (...args: any[]) => void, ...args: any[])`](#api-evaluate)
 - [`inputValue(selector: string)`](#api-inputvalue)
@@ -250,6 +251,23 @@ __Example__
 
 ```js
 await chromeless.scrollTo(500, 0)
+```
+
+---------------------------------------
+
+<a name="api-setdocumentcontent" />
+
+### setDocumentContent(html: string): Chromeless<T>
+
+Sets given markup as the document's HTML.
+
+__Arguments__
+- `html` - HTML to set as the document's markup.
+
+__Example__
+
+```js
+await chromeless.setDocumentContent('<h1>Hello world!</h1>')
 ```
 
 ---------------------------------------

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,7 +20,7 @@ Chromeless provides TypeScript typings.
 - [`mousedown()`](#api-mousedown) - Not implemented yet
 - [`mouseup()`](#api-mouseup) - Not implemented yet
 - [`scrollTo(x: number, y: number)`](#api-scrollto)
-- [`setDocumentContent(html: string)`](#api-setdocumentcontent)
+- [`setHtml(html: string)`](#api-sethtml)
 - [`viewport(width: number, height: number)`](#api-viewport)
 - [`evaluate<U extends any>(fn: (...args: any[]) => void, ...args: any[])`](#api-evaluate)
 - [`inputValue(selector: string)`](#api-inputvalue)
@@ -256,9 +256,9 @@ await chromeless.scrollTo(500, 0)
 
 ---------------------------------------
 
-<a name="api-setdocumentcontent" />
+<a name="api-sethtml" />
 
-### setDocumentContent(html: string): Chromeless<T>
+### setHtml(html: string): Chromeless<T>
 
 Sets given markup as the document's HTML.
 
@@ -268,7 +268,7 @@ __Arguments__
 __Example__
 
 ```js
-await chromeless.setDocumentContent('<h1>Hello world!</h1>')
+await chromeless.setHtml('<h1>Hello world!</h1>')
 ```
 
 ---------------------------------------

--- a/src/api.ts
+++ b/src/api.ts
@@ -142,6 +142,12 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return this
   }
 
+  setDocumentContent(html: string): Chromeless<T> {
+    this.queue.enqueue({type: 'setDocumentContent', html})
+
+    return this
+  }
+
   viewport(width: number, height: number): Chromeless<T> {
     throw new Error('Not implemented yet')
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -142,8 +142,8 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return this
   }
 
-  setDocumentContent(html: string): Chromeless<T> {
-    this.queue.enqueue({type: 'setDocumentContent', html})
+  setHtml(html: string): Chromeless<T> {
+    this.queue.enqueue({type: 'setHtml', html})
 
     return this
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -176,6 +176,12 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return new Chromeless<string>({}, this)
   }
 
+  getHtml(): Chromeless<string> {
+    this.lastReturnPromise = this.queue.process<string>({type: 'returnHtml'})
+
+    return new Chromeless<string>({}, this)
+  }
+
   /**
    * Get the cookies for the current url
    */

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -9,6 +9,7 @@ import {
   click,
   evaluate,
   screenshot,
+  html,
   type,
   getValue,
   scrollTo,
@@ -50,6 +51,8 @@ export default class LocalRuntime {
         return this.returnExists(command.selector)
       case 'returnScreenshot':
         return this.returnScreenshot()
+      case 'returnHtml':
+        return this.returnHtml()
       case 'returnInputValue':
         return this.returnInputValue(command.selector)
       case 'type':
@@ -213,6 +216,10 @@ export default class LocalRuntime {
 
       return filePath
     }
+  }
+
+  async returnHtml(): Promise<string> {
+    return await html(this.client)
   }
 
   private log(msg: string): void {

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -12,7 +12,7 @@ import {
   type,
   getValue,
   scrollTo,
-  setDocumentContent,
+  setHtml,
   press,
   clearCookies,
   getCookies,
@@ -58,8 +58,8 @@ export default class LocalRuntime {
         return this.press(command.keyCode, command.count, command.modifiers)
       case 'scrollTo':
         return this.scrollTo(command.x, command.y)
-      case 'setDocumentContent':
-        return this.setDocumentContent(command.html)
+      case 'setHtml':
+        return this.setHtml(command.html)
       case 'cookiesClearAll':
         return this.cookiesClearAll()
       case 'cookiesGet':
@@ -117,8 +117,8 @@ export default class LocalRuntime {
     return scrollTo(this.client, x, y)
   }
 
-  private async setDocumentContent(html: string): Promise<void> {
-    await setDocumentContent(this.client, html)
+  private async setHtml(html: string): Promise<void> {
+    await setHtml(this.client, html)
   }
 
   async type(text: string, selector?: string): Promise<void> {

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -12,6 +12,7 @@ import {
   type,
   getValue,
   scrollTo,
+  setDocumentContent,
   press,
   clearCookies,
   getCookies,
@@ -57,6 +58,8 @@ export default class LocalRuntime {
         return this.press(command.keyCode, command.count, command.modifiers)
       case 'scrollTo':
         return this.scrollTo(command.x, command.y)
+      case 'setDocumentContent':
+        return this.setDocumentContent(command.html)
       case 'cookiesClearAll':
         return this.cookiesClearAll()
       case 'cookiesGet':
@@ -112,6 +115,10 @@ export default class LocalRuntime {
 
   private async scrollTo<T>(x: number, y: number): Promise<void> {
     return scrollTo(this.client, x, y)
+  }
+
+  private async setDocumentContent(html: string): Promise<void> {
+    await setDocumentContent(this.client, html)
   }
 
   async type(text: string, selector?: string): Promise<void> {

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -9,7 +9,7 @@ import {
   click,
   evaluate,
   screenshot,
-  html,
+  getHtml,
   type,
   getValue,
   scrollTo,
@@ -219,7 +219,7 @@ export default class LocalRuntime {
   }
 
   async returnHtml(): Promise<string> {
-    return await html(this.client)
+    return await getHtml(this.client)
   }
 
   private log(msg: string): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface Client {
   Network: any
   Page: any
+  DOM: any
   Input: any
   Runtime: any
   Emulation: any
@@ -75,6 +76,9 @@ export type Command =
     }
   | {
       type: 'returnScreenshot'
+    }
+  | {
+      type: 'returnHtml'
     }
   | {
       type: 'scrollTo'

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,7 @@ export type Command =
       y: number
     }
   | {
-      type: 'setDocumentContent',
+      type: 'setHtml',
       html: string
     }
   | {

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,10 @@ export type Command =
       y: number
     }
   | {
+      type: 'setDocumentContent',
+      html: string
+    }
+  | {
       type: 'press'
       keyCode: number
       count?: number

--- a/src/util.ts
+++ b/src/util.ts
@@ -238,6 +238,13 @@ export async function scrollTo(client: Client, x: number, y: number): Promise<vo
   })
 }
 
+export async function setDocumentContent(client: Client, html: string): Promise<void> {
+  const {Page} = client
+
+  const {frameTree: {frame: {id: frameId}}} = await Page.getResourceTree()
+  await Page.setDocumentContent({frameId, html})
+}
+
 export async function getCookies(client: Client, nameOrQuery?: string | Cookie): Promise<any> {
   if (nameOrQuery) {
     throw new Error('Not yet implemented')

--- a/src/util.ts
+++ b/src/util.ts
@@ -238,7 +238,7 @@ export async function scrollTo(client: Client, x: number, y: number): Promise<vo
   })
 }
 
-export async function setDocumentContent(client: Client, html: string): Promise<void> {
+export async function setHtml(client: Client, html: string): Promise<void> {
   const {Page} = client
 
   const {frameTree: {frame: {id: frameId}}} = await Page.getResourceTree()

--- a/src/util.ts
+++ b/src/util.ts
@@ -297,7 +297,7 @@ export async function screenshot(client: Client): Promise<string> {
   return screenshot.data
 }
 
-export async function html(client: Client): Promise<string> {
+export async function getHtml(client: Client): Promise<string> {
   const {DOM} = client
 
   const {root: {nodeId}} = await DOM.getDocument()

--- a/src/util.ts
+++ b/src/util.ts
@@ -297,6 +297,14 @@ export async function screenshot(client: Client): Promise<string> {
   return screenshot.data
 }
 
+export async function html(client: Client): Promise<string> {
+  const {DOM} = client
+
+  const {root: {nodeId}} = await DOM.getDocument()
+  const {outerHTML} = await DOM.getOuterHTML({nodeId})
+  return outerHTML
+}
+
 export function getDebugOption(): boolean {
   if (process && process.env && process.env['DEBUG'] && process.env['DEBUG'].includes('chromeless')) {
     return true


### PR DESCRIPTION
This implements an API at `setHtml()` to call [Page.setDocumentContent](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-setDocumentContent), allowing the user to pass arbitrary HTML to Chrome instead of calling a URL.

It also implements an API at `getHtml()` that allows the user to get the page's HTML.

Example usage:
```js
const { Chromeless } = require('chromeless')

async function run() {
  const chromeless = new Chromeless()

  const html = await chromeless
    .setHtml('<h1>Hello world!</h1>')
    .getHtml()

  console.log(html)

  await chromeless.end()
}

run().catch(console.error.bind(console))
```

Running this logs the following content:
```html
<html><head></head><body><h1>Hello world!</h1></body></html>
```

Another example of `getHtml()`, on an actual web page:
```js
chromeless
  .goto('http://www.google.com/')
  .getHtml()
```