### PR TITLE
provide .viewport() functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ const chromeless = new Chromeless({
 
 **Chrome methods**
 - [`goto(url: string)`](docs/api.md#api-goto)
-- [`viewport(options: DeviceMetrics)`](docs/api.md#api-viewport)
 - [`click(selector: string)`](docs/api.md#api-click)
 - [`wait(timeout: number)`](docs/api.md#api-wait-timeout)
 - [`wait(selector: string)`](docs/api.md#api-wait-selector)
@@ -156,7 +155,7 @@ const chromeless = new Chromeless({
 - [`mousedown()`](docs/api.md#api-mousedown) - Not implemented yet
 - [`mouseup()`](docs/api.md#api-mouseup) - Not implemented yet
 - [`scrollTo(x: number, y: number)`](docs/api.md#api-scrollto)
-- [`viewport(width: number, height: number)`](docs/api.md#api-viewport)
+- [`viewport(options: DeviceMetrics)`](docs/api.md#api-viewport)
 - [`evaluate<U extends any>(fn: (...args: any[]) => void, ...args: any[])`](docs/api.md#api-evaluate)
 - [`inputValue(selector: string)`](docs/api.md#api-inputvalue)
 - [`exists(selector: string)`](docs/api.md#api-exists)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ const chromeless = new Chromeless({
 - [`mouseup(selector: string)`](docs/api.md#api-mouseup)
 - [`scrollTo(x: number, y: number)`](docs/api.md#api-scrollto)
 - [`setHtml(html: string)`](docs/api.md#api-sethtml)
-- [`viewport(options: DeviceMetrics)`](docs/api.md#api-viewport)
+- [`setViewport(options: DeviceMetrics)`](docs/api.md#api-setviewport)
 - [`evaluate<U extends any>(fn: (...args: any[]) => void, ...args: any[])`](docs/api.md#api-evaluate)
 - [`inputValue(selector: string)`](docs/api.md#api-inputvalue)
 - [`exists(selector: string)`](docs/api.md#api-exists)

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ const chromeless = new Chromeless({
 
 **Chrome methods**
 - [`goto(url: string)`](docs/api.md#api-goto)
+- [`viewport(options: DeviceMetrics)`](docs/api.md#api-viewport)
 - [`click(selector: string)`](docs/api.md#api-click)
 - [`wait(timeout: number)`](docs/api.md#api-wait-timeout)
 - [`wait(selector: string)`](docs/api.md#api-wait-selector)

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,7 +7,6 @@ Chromeless provides TypeScript typings.
 
 **Chrome methods**
 - [`goto(url: string)`](#api-goto)
-- [`viewport(options: DeviceMetrics)`](#api-viewport)
 - [`click(selector: string)`](#api-click)
 - [`wait(timeout: number)`](#api-wait-timeout)
 - [`wait(selector: string)`](#api-wait-selector)
@@ -21,7 +20,7 @@ Chromeless provides TypeScript typings.
 - [`mousedown()`](#api-mousedown) - Not implemented yet
 - [`mouseup()`](#api-mouseup) - Not implemented yet
 - [`scrollTo(x: number, y: number)`](#api-scrollto)
-- [`viewport(width: number, height: number)`](#api-viewport)
+- [`viewport(options: DeviceMetrics)`](#api-viewport)
 - [`evaluate<U extends any>(fn: (...args: any[]) => void, ...args: any[])`](#api-evaluate)
 - [`inputValue(selector: string)`](#api-inputvalue)
 - [`exists(selector: string)`](#api-exists)
@@ -66,23 +65,6 @@ __Example__
 
 ```js
 await chromeless.goto('https://google.com/')
-```
-
----------------------------------------
-
-<a name="api-viewport" />
-
-### viewport(options: DeviceMetrics): Chromeless<T>
-
-Adjust the viewport metrics of the browser.
-
-__Arguments__
-- `options` - an object with some required fields (width, height)
-
-__Example__
-
-```js
-await chromeless.viewport({ width: 1024, height: 600 })
 ```
 
 ---------------------------------------

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,7 +21,7 @@ Chromeless provides TypeScript typings.
 - [`mouseup(selector: string)`](#api-mouseup)
 - [`scrollTo(x: number, y: number)`](#api-scrollto)
 - [`setHtml(html: string)`](#api-sethtml)
-- [`viewport(options: DeviceMetrics)`](#api-viewport)
+- [`setViewport(options: DeviceMetrics)`](#api-setviewport)
 - [`evaluate<U extends any>(fn: (...args: any[]) => void, ...args: any[])`](#api-evaluate)
 - [`inputValue(selector: string)`](#api-inputvalue)
 - [`exists(selector: string)`](#api-exists)
@@ -293,20 +293,19 @@ await chromeless.setHtml('<h1>Hello world!</h1>')
 
 ---------------------------------------
 
-<a name="api-viewport" />
+<a name="api-setviewport" />
 
-### viewport(width: number, height: number)
+### setViewport(options:DeviceMetrics)
 
 Resize the viewport. Useful if you want to capture more or less of the document in a screenshot.
 
 __Arguments__
-- `width` - Viewport width
-- `height` - Viewport height
+- `options` - DeviceMetrics object
 
 __Example__
 
 ```js
-await chromeless.viewport(1024, 800)
+await chromeless.setViewport({width: 1024, height: 600, scale: 1})
 ```
 
 ---------------------------------------

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,6 +7,7 @@ Chromeless provides TypeScript typings.
 
 **Chrome methods**
 - [`goto(url: string)`](#api-goto)
+- [`viewport(options: DeviceMetrics)`](#api-viewport)
 - [`click(selector: string)`](#api-click)
 - [`wait(timeout: number)`](#api-wait-timeout)
 - [`wait(selector: string)`](#api-wait-selector)
@@ -65,6 +66,23 @@ __Example__
 
 ```js
 await chromeless.goto('https://google.com/')
+```
+
+---------------------------------------
+
+<a name="api-viewport" />
+
+### viewport(options: DeviceMetrics): Chromeless<T>
+
+Adjust the viewport metrics of the browser.
+
+__Arguments__
+- `options` - an object with some required fields (width, height)
+
+__Example__
+
+```js
+await chromeless.viewport({ width: 1024, height: 600 })
 ```
 
 ---------------------------------------

--- a/src/api.ts
+++ b/src/api.ts
@@ -145,8 +145,8 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return this
   }
 
-  viewport(options: DeviceMetrics): Chromeless<T> {
-    this.queue.enqueue({type: 'viewport', options})
+  setViewport(options: DeviceMetrics): Chromeless<T> {
+    this.queue.enqueue({type: 'setViewport', options})
 
     return this
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,7 @@
 import ChromeLocal from './chrome/local'
 import ChromeRemote from './chrome/remote'
 import Queue from './queue'
-import { ChromelessOptions, Cookie, CookieQuery } from './types'
+import { ChromelessOptions, Cookie, CookieQuery, DeviceMetrics } from './types'
 import { getDebugOption } from './util'
 
 export default class Chromeless<T extends any> implements Promise<T> {
@@ -142,8 +142,10 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return this
   }
 
-  viewport(width: number, height: number): Chromeless<T> {
-    throw new Error('Not implemented yet')
+  viewport(options: DeviceMetrics): Chromeless<T> {
+    this.queue.enqueue({type: 'viewport', options})
+
+    return this
   }
 
   evaluate<U extends any>(fn: (...args: any[]) => void, ...args: any[]): Chromeless<U> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -155,19 +155,13 @@ export default class Chromeless<T extends any> implements Promise<T> {
   }
 
   setViewport(options: DeviceMetrics): Chromeless<T> {
-    this.queue.enqueue({type: 'setViewport', options})
-    
+    this.queue.enqueue({ type: 'setViewport', options })
+
     return this
   }
 
   setHtml(html: string): Chromeless<T> {
     this.queue.enqueue({ type: 'setHtml', html })
-
-    return this
-  }
-
-  setHtml(html: string): Chromeless<T> {
-    this.queue.enqueue({type: 'setHtml', html})
 
     return this
   }

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -21,7 +21,7 @@ import {
   setCookies,
   getAllCookies,
   version,
-  mousedown, 
+  mousedown,
   mouseup
 } from '../util'
 
@@ -39,7 +39,7 @@ export default class LocalRuntime {
     switch (command.type) {
       case 'goto':
         return this.goto(command.url)
-        case 'viewport':
+        case 'setViewport':
           return setViewport(this.client, command.options)
       case 'wait': {
         if (command.timeout) {
@@ -87,28 +87,6 @@ export default class LocalRuntime {
     }
   }
 
-  private async viewport(width: number, height: number): Promise<void> {
-      // TODO what to configure
-      const config: any = {
-          deviceScaleFactor: 1,
-          mobile: false,
-          scale: 1,
-          fitWindow: false, // as we cannot resize the window, `fitWindow: false` is needed in order for the viewport to be resizable
-      }
-
-      if (height > 0 && width > 0) {
-          config.height = height
-          config.width = width
-      }
-
-      await this.client.Emulation.setDeviceMetricsOverride(config)
-      await this.client.Emulation.setVisibleSize({
-          width: config.width,
-          height: config.height,
-      })
-      this.log(`Adjusted viewport to ${width}x${height}`)
-  }
-
   private async goto(url: string): Promise<void> {
     const {Network, Page} = this.client
     await Promise.all([Network.enable(), Page.enable()])
@@ -154,9 +132,9 @@ export default class LocalRuntime {
   }
 
   private async mousedown(selector: string): Promise<void> {
-      if (this.chromlessOptions.implicitWait) {
+      if (this.chromelessOptions.implicitWait) {
           this.log(`mousedown(): Waiting for ${selector}`)
-          await waitForNode(this.client, selector, this.chromlessOptions.waitTimeout)
+          await waitForNode(this.client, selector, this.chromelessOptions.waitTimeout)
       }
 
       const exists = await nodeExists(this.client, selector)
@@ -164,15 +142,15 @@ export default class LocalRuntime {
           throw new Error(`mousedown(): node for selector ${selector} doesn't exist`)
       }
 
-      const {scale} = this.chromlessOptions.viewport
+      const {scale} = this.chromelessOptions.viewport
       await mousedown(this.client, selector, scale)
       this.log(`Mousedown on ${selector}`)
   }
 
   private async mousup(selector: string): Promise<void> {
-      if (this.chromlessOptions.implicitWait) {
+      if (this.chromelessOptions.implicitWait) {
           this.log(`mouseup(): Waiting for ${selector}`)
-          await waitForNode(this.client, selector, this.chromlessOptions.waitTimeout)
+          await waitForNode(this.client, selector, this.chromelessOptions.waitTimeout)
       }
 
       const exists = await nodeExists(this.client, selector)
@@ -180,7 +158,7 @@ export default class LocalRuntime {
           throw new Error(`mouseup(): node for selector ${selector} doesn't exist`)
       }
 
-      const {scale} = this.chromlessOptions.viewport
+      const {scale} = this.chromelessOptions.viewport
       await mouseup(this.client, selector, scale)
       this.log(`Mouseup on ${selector}`)
   }

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -236,7 +236,6 @@ export default class LocalRuntime {
   }
 
   private log(msg: string): void {
-    console.log('>', this.chromlessOptions.debug)
     if (this.chromlessOptions.debug) {
       console.log(msg)
     }

--- a/src/chrome/local.ts
+++ b/src/chrome/local.ts
@@ -2,8 +2,7 @@ import { Chrome, Command, ChromelessOptions, Client } from '../types'
 import * as CDP from 'chrome-remote-interface'
 import { LaunchedChrome, launch } from 'chrome-launcher'
 import LocalRuntime from './local-runtime'
-import { 
-} from '../util'
+import { evaluate, setViewport } from '../util'
 import { DeviceMetrics } from '../types'
 
 interface RuntimeClient {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,20 @@ export interface Client {
   }
 }
 
+export interface DeviceMetrics {
+  width: number
+  height: number
+  deviceScaleFactor?: number
+  mobile?: boolean
+  scale?: number
+  screenOrientation?: ScreenOrientation
+}
+
+export interface ScreenOrientation {
+  type: string
+  angle: number
+}
+
 export interface RemoteOptions {
   endpointUrl: string
   apiKey?: string
@@ -45,6 +59,10 @@ export type Command =
       type: 'goto'
       url: string
     }
+  | {
+      type: 'viewport'
+      options: DeviceMetrics
+  }
   | {
       type: 'wait'
       timeout?: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ export type Command =
       url: string
     }
   | {
-      type: 'viewport'
+      type: 'setViewport'
       options: DeviceMetrics
   }
   | {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs'
 import * as path from 'path'
-import { Client, Cookie } from './types'
-import { DeviceMetrics } from './types'
+import { Client, Cookie, DeviceMetrics } from './types'
 import * as CDP from 'chrome-remote-interface'
 
 export const version: string = ((): string => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { Client, Cookie } from './types'
+import { DeviceMetrics } from './types'
+import * as CDP from 'chrome-remote-interface'
 
 export const version: string = ((): string => {
   if (fs.existsSync(path.join(__dirname, '../package.json'))) {
@@ -11,6 +13,43 @@ export const version: string = ((): string => {
     return require('../../package.json').version
   }
 })()
+
+export async function setViewport(client: Client, viewport: DeviceMetrics = { width: 1, height: 1, scale: 1 }): Promise<void> {
+  const config: any = {
+      deviceScaleFactor: 1,
+      mobile: false,
+      scale: viewport.scale || 1,
+      fitWindow: false, // as we cannot resize the window, `fitWindow: false` is needed in order for the viewport to be resizable
+  }
+
+  const versionResult = await CDP.Version()
+  const isHeadless = versionResult['User-Agent'].includes('Headless')
+
+  if (viewport.height && viewport.width) {
+      config.height = viewport.height
+      config.width = viewport.width
+  } else if (isHeadless) {
+      // just apply default value in headless mode to maintain original browser viewport
+      config.height = 900
+      config.width = 1440
+  } else {
+      config.height = await evaluate(
+          client,
+          (() => window.innerHeight).toString()
+      )
+      config.width = await evaluate(
+          client,
+          (() => window.innerWidth).toString()
+      )
+  }
+
+  await client.Emulation.setDeviceMetricsOverride(config)
+  await client.Emulation.setVisibleSize({
+      width: config.width,
+      height: config.height,
+  })
+  return
+}
 
 export async function waitForNode(client: Client, selector: string, waitTimeout: number): Promise<void> {
   const {Runtime} = client


### PR DESCRIPTION
use the current viewport functionality and provide it as an api.

Probably this was not implemented because Chromium provides more options than Nightmare/Phantomjs currently. So I created a DeviceMetrics interface as described at [Devtools Protocol](https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#type-ScreenOrientation).

So `.setViewport({width: 1024, height: 600, scale: 1, ...})` is preferred above using comma separated values.

Fixes #75 