### PR TITLE
provide .useragent() functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CHANGELOG.md @adieuadieu
 - LICENSE file (MIT) @adieuadieu
 - `implicitWait`: By default wait for `.press` and `.click` for a cleaner workflow
-- `.setUseragent()` is added to customize the userAgent you want to sent with your browser request 
+- `.setUserAgent()` is added to customize the userAgent you want to sent with your browser request @joeyvandijk
 
 ### Changed
 - `.end()`: now returns the last value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Ensure latest version of Serverless is used during deployment. [#58](https://github.com/graphcool/chromeless/issues/58)
 - package repository url [#64](https://github.com/graphcool/chromeless/pull/64) @Hazealign
-
+- `.setUserAgent()` is added to customize the userAgent you want to sent with your browser request [#117] @joeyvandijk
 
 ## [1.1.0] - 2017-07-27
 ### Added
 - CHANGELOG.md @adieuadieu
 - LICENSE file (MIT) @adieuadieu
 - `implicitWait`: By default wait for `.press` and `.click` for a cleaner workflow
-- `.setUserAgent()` is added to customize the userAgent you want to sent with your browser request @joeyvandijk
 
 ### Changed
 - `.end()`: now returns the last value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CHANGELOG.md @adieuadieu
 - LICENSE file (MIT) @adieuadieu
 - `implicitWait`: By default wait for `.press` and `.click` for a cleaner workflow
+- `.setUseragent()` is added to customize the userAgent you want to sent with your browser request 
 
 ### Changed
 - `.end()`: now returns the last value

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ const chromeless = new Chromeless({
 
 **Chrome methods**
 - [`goto(url: string)`](docs/api.md#api-goto)
-- [`useragent(useragent: string)`](docs/api.md#api-useragent)
+- [`useragentSet(useragent: string)`](docs/api.md#api-useragentSet)
 - [`click(selector: string)`](docs/api.md#api-click)
 - [`wait(timeout: number)`](docs/api.md#api-wait-timeout)
 - [`wait(selector: string)`](docs/api.md#api-wait-selector)

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ const chromeless = new Chromeless({
 
 **Chrome methods**
 - [`goto(url: string)`](docs/api.md#api-goto)
-- [`useragentSet(useragent: string)`](docs/api.md#api-useragentSet)
+- [`setUserAgent(useragent: string)`](docs/api.md#api-setUserAgent)
 - [`click(selector: string)`](docs/api.md#api-click)
 - [`wait(timeout: number)`](docs/api.md#api-wait-timeout)
 - [`wait(selector: string)`](docs/api.md#api-wait-selector)

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ const chromeless = new Chromeless({
 
 **Chrome methods**
 - [`goto(url: string)`](docs/api.md#api-goto)
+- [`useragent(useragent: string)`](docs/api.md#api-useragent)
 - [`click(selector: string)`](docs/api.md#api-click)
 - [`wait(timeout: number)`](docs/api.md#api-wait-timeout)
 - [`wait(selector: string)`](docs/api.md#api-wait-selector)

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,6 +7,7 @@ Chromeless provides TypeScript typings.
 
 **Chrome methods**
 - [`goto(url: string)`](#api-goto)
+- [`useragent(useragent: string)`](#api-useragent)
 - [`click(selector: string)`](#api-click)
 - [`wait(timeout: number)`](#api-wait-timeout)
 - [`wait(selector: string)`](#api-wait-selector)
@@ -65,6 +66,23 @@ __Example__
 
 ```js
 await chromeless.goto('https://google.com/')
+```
+
+---------------------------------------
+
+<a name="api-useragent" />
+
+### useragent(useragent: string): Chromeless<T>
+
+Set the useragent of the browser. It should be called before `.goto()`.
+
+__Arguments__
+- `useragent` - Useragent to use
+
+__Example__
+
+```js
+await chromeless.useragent('Custom Chromeless UserAgent x.x.x')
 ```
 
 ---------------------------------------

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,7 +7,7 @@ Chromeless provides TypeScript typings.
 
 **Chrome methods**
 - [`goto(url: string)`](#api-goto)
-- [`useragent(useragent: string)`](#api-useragent)
+- [`useragentSet(useragent: string)`](#api-useragentSet)
 - [`click(selector: string)`](#api-click)
 - [`wait(timeout: number)`](#api-wait-timeout)
 - [`wait(selector: string)`](#api-wait-selector)
@@ -70,9 +70,9 @@ await chromeless.goto('https://google.com/')
 
 ---------------------------------------
 
-<a name="api-useragent" />
+<a name="api-useragentSet" />
 
-### useragent(useragent: string): Chromeless<T>
+### useragentSet(useragent: string): Chromeless<T>
 
 Set the useragent of the browser. It should be called before `.goto()`.
 
@@ -82,7 +82,7 @@ __Arguments__
 __Example__
 
 ```js
-await chromeless.useragent('Custom Chromeless UserAgent x.x.x')
+await chromeless.useragentSet('Custom Chromeless UserAgent x.x.x')
 ```
 
 ---------------------------------------

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,7 +7,7 @@ Chromeless provides TypeScript typings.
 
 **Chrome methods**
 - [`goto(url: string)`](#api-goto)
-- [`useragentSet(useragent: string)`](#api-useragentSet)
+- [`setUserAgent(useragent: string)`](#api-setuseragent)
 - [`click(selector: string)`](#api-click)
 - [`wait(timeout: number)`](#api-wait-timeout)
 - [`wait(selector: string)`](#api-wait-selector)
@@ -70,19 +70,19 @@ await chromeless.goto('https://google.com/')
 
 ---------------------------------------
 
-<a name="api-useragentSet" />
+<a name="api-setuseragent" />
 
-### useragentSet(useragent: string): Chromeless<T>
+### setUserAgent(useragent: string): Chromeless<T>
 
 Set the useragent of the browser. It should be called before `.goto()`.
 
 __Arguments__
-- `useragent` - Useragent to use
+- `useragent` - UserAgent to use
 
 __Example__
 
 ```js
-await chromeless.useragentSet('Custom Chromeless UserAgent x.x.x')
+await chromeless.setUserAgent('Custom Chromeless UserAgent x.x.x')
 ```
 
 ---------------------------------------

--- a/src/api.ts
+++ b/src/api.ts
@@ -66,8 +66,8 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return this
   }
 
-  useragent(useragent: string): Chromeless<T> {
-    this.queue.enqueue({type: 'useragent', useragent})
+  useragentSet(useragent: string): Chromeless<T> {
+    this.queue.enqueue({type: 'useragentSet', useragent})
 
     return this
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -66,8 +66,8 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return this
   }
 
-  useragentSet(useragent: string): Chromeless<T> {
-    this.queue.enqueue({type: 'useragentSet', useragent})
+  setUserAgent(useragent: string): Chromeless<T> {
+    this.queue.enqueue({type: 'setUserAgent', useragent})
 
     return this
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -66,6 +66,12 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return this
   }
 
+  useragent(useragent: string): Chromeless<T> {
+    this.queue.enqueue({type: 'useragent', useragent})
+
+    return this
+  }
+
   click(selector: string): Chromeless<T> {
     this.queue.enqueue({type: 'click', selector})
 

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -22,6 +22,7 @@ export default class LocalRuntime {
 
   private client: Client
   private chromlessOptions: ChromelessOptions
+  private userAgentValue: string
 
   constructor(client: Client, chromlessOptions: ChromelessOptions) {
     this.client = client
@@ -41,6 +42,8 @@ export default class LocalRuntime {
           throw new Error('waitFn not yet implemented')
         }
       }
+      case 'useragent':
+        return this.useragent(command.useragent)
       case 'click':
         return this.click(command.selector)
       case 'returnCode':
@@ -70,10 +73,16 @@ export default class LocalRuntime {
     }
   }
 
+  private async useragent(useragent: string): Promise<void> {
+    this.userAgentValue = useragent
+    await this.log(`Set useragent to ${this.userAgentValue}`)
+  }
+
   private async goto(url: string): Promise<void> {
     const {Network, Page} = this.client
     await Promise.all([Network.enable(), Page.enable()])
-    await Network.setUserAgentOverride({userAgent: `Chromeless ${version}`})
+    if (!this.userAgentValue) this.userAgentValue = `Chromeless ${version}`
+    await Network.setUserAgentOverride({userAgent: this.userAgentValue})
     await Page.navigate({url})
     await Page.loadEventFired()
     this.log(`Navigated to ${url}`)

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -42,8 +42,8 @@ export default class LocalRuntime {
           throw new Error('waitFn not yet implemented')
         }
       }
-      case 'useragent':
-        return this.useragent(command.useragent)
+      case 'useragentSet':
+        return this.useragentSet(command.useragent)
       case 'click':
         return this.click(command.selector)
       case 'returnCode':
@@ -73,11 +73,6 @@ export default class LocalRuntime {
     }
   }
 
-  private async useragent(useragent: string): Promise<void> {
-    this.userAgentValue = useragent
-    await this.log(`Set useragent to ${this.userAgentValue}`)
-  }
-
   private async goto(url: string): Promise<void> {
     const {Network, Page} = this.client
     await Promise.all([Network.enable(), Page.enable()])
@@ -86,6 +81,11 @@ export default class LocalRuntime {
     await Page.navigate({url})
     await Page.loadEventFired()
     this.log(`Navigated to ${url}`)
+  }
+
+  private async useragentSet(useragent: string): Promise<void> {
+    this.userAgentValue = useragent
+    await this.log(`Set useragent to ${this.userAgentValue}`)
   }
 
   private async waitTimeout(timeout: number): Promise<void> {

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -42,8 +42,8 @@ export default class LocalRuntime {
           throw new Error('waitFn not yet implemented')
         }
       }
-      case 'useragentSet':
-        return this.useragentSet(command.useragent)
+      case 'setUserAgent':
+        return this.setUserAgent(command.useragent)
       case 'click':
         return this.click(command.selector)
       case 'returnCode':
@@ -83,7 +83,7 @@ export default class LocalRuntime {
     this.log(`Navigated to ${url}`)
   }
 
-  private async useragentSet(useragent: string): Promise<void> {
+  private async setUserAgent(useragent: string): Promise<void> {
     this.userAgentValue = useragent
     await this.log(`Set useragent to ${this.userAgentValue}`)
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,7 @@ export type Command =
       url: string
     }
   | {
-      type: 'useragentSet'
+      type: 'setUserAgent'
       useragent: string
     }
   | {

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,7 @@ export type Command =
       url: string
     }
   | {
-      type: 'useragent'
+      type: 'useragentSet'
       useragent: string
     }
   | {

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,10 @@ export type Command =
       url: string
     }
   | {
+      type: 'useragent'
+      useragent: string
+    }
+  | {
       type: 'wait'
       timeout?: number
       selector?: string


### PR DESCRIPTION
Be able to change the `User-Agent` of a http(s) request. It should be noted that this is only possible when it is called before the `.goto()` function.

Tested with RequestBin and perhaps the PR for https://github.com/graphcool/chromeless/issues/71 ?