### PR TITLE
rewrite cookie endpoints: deleteCookies & clearCookies and fix clearCookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ const chromeless = new Chromeless({
 - [`cookiesSet(name: string, value: string)`](docs/api.md#api-cookiesset)
 - [`cookiesSet(cookie: Cookie)`](docs/api.md#api-cookiesset-one)
 - [`cookiesSet(cookies: Cookie[])`](docs/api.md#api-cookiesset-many)
-- [`cookiesClear(name: string)`](docs/api.md#api-cookiesclear)
-- [`cookiesClearAll()`](docs/api.md#api-cookiesclearall)
+- [`cookiesDelete(name: string)`](docs/api.md#api-cookiesdelete)
+- [`cookiesClear()`](docs/api.md#api-cookiesclear)
 
 ## Configuring Development Environment
 

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ const chromeless = new Chromeless({
 - [`cookiesSet(name: string, value: string)`](docs/api.md#api-cookiesset)
 - [`cookiesSet(cookie: Cookie)`](docs/api.md#api-cookiesset-one)
 - [`cookiesSet(cookies: Cookie[])`](docs/api.md#api-cookiesset-many)
-- [`cookiesDelete(name: string)`](docs/api.md#api-cookiesdelete)
-- [`cookiesClear()`](docs/api.md#api-cookiesclear)
+- [`deleteCookies(name: string)`](docs/api.md#api-deletecookies)
+- [`clearCookies()`](docs/api.md#api-clearcookies)
 - [`clearInput(selector: string)`](docs/api.md#api-clearInput)
 
 ## Configuring Development Environment

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,8 +36,8 @@ Chromeless provides TypeScript typings.
 - [`cookiesSet(name: string, value: string)`](#api-cookiesset)
 - [`cookiesSet(cookie: Cookie)`](#api-cookiesset-one)
 - [`cookiesSet(cookies: Cookie[])`](#api-cookiesset-many)
-- [`cookiesDelete(name: string)`](#api-cookiesdelete)
-- [`cookiesClear()`](#api-cookiesclear)
+- [`deleteCookies(name: string)`](#api-deletecookies)
+- [`clearCookies()`](#api-clearcookies)
 
 
 ---------------------------------------
@@ -589,9 +589,9 @@ await chromeless.cookiesSet([
 
 ---------------------------------------
 
-<a name="api-cookiesclear" />
+<a name="api-deletecookies" />
 
-### cookiesDelete(name: string) - Not implemented yet
+### deleteCookies(name: string) - Not implemented yet
 
 Delete a specific cookie.
 
@@ -601,21 +601,21 @@ __Arguments__
 __Example__
 
 ```js
-await chromeless.cookiesDelete('cookieName')
+await chromeless.deleteCookies('cookieName')
 ```
 
 ---------------------------------------
 
-<a name="api-cookiesclear" />
+<a name="api-clearcookies" />
 
-### cookiesClear(): Chromeless<T>
+### clearCookies(): Chromeless<T>
 
 Clears all browser cookies.
 
 __Example__
 
 ```js
-await chromeless.cookiesClear()
+await chromeless.clearCookies()
 ```
 ---------------------------------------
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,8 +33,8 @@ Chromeless provides TypeScript typings.
 - [`cookiesSet(name: string, value: string)`](#api-cookiesset)
 - [`cookiesSet(cookie: Cookie)`](#api-cookiesset-one)
 - [`cookiesSet(cookies: Cookie[])`](#api-cookiesset-many)
-- [`cookiesClear(name: string)`](#api-cookiesclear)
-- [`cookiesClearAll()`](#api-cookiesclearall)
+- [`cookiesDelete(name: string)`](#api-cookiesdelete)
+- [`cookiesClear()`](#api-cookiesclear)
 
 
 ---------------------------------------
@@ -501,21 +501,29 @@ await chromeless.cookiesSet([
 
 <a name="api-cookiesclear" />
 
-### cookiesClear(name: string) - Not implemented yet
+### cookiesDelete(name: string) - Not implemented yet
 
-Not implemented yet
+Delete a specific cookie.
 
----------------------------------------
-
-<a name="api-cookiesclearall" />
-
-### cookiesClearAll(): Chromeless<T>
-
-Clears browser cookies.
-
+__Arguments__
+- `name` - name of the cookie
 
 __Example__
 
 ```js
-await chromeless.cookiesClearAll()
+await chromeless.cookiesDelete('cookieName')
+```
+
+---------------------------------------
+
+<a name="api-cookiesclear" />
+
+### cookiesClear(): Chromeless<T>
+
+Clears all browser cookies.
+
+__Example__
+
+```js
+await chromeless.cookiesClear()
 ```

--- a/src/api.ts
+++ b/src/api.ts
@@ -209,12 +209,20 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return this
   }
 
-  cookiesClear(name: string): Chromeless<T> {
-    throw new Error('Not implemented yet')
+  cookiesDelete(name: string, url: string): Chromeless<T> {
+    if (typeof name === 'undefined') {
+      throw new Error('Cookie name should be defined.')
+    }
+    if (typeof url === 'undefined') {
+      throw new Error('Cookie url should be defined.')
+    }
+    this.queue.enqueue({type: 'cookiesDelete', name, url})
+
+    return this
   }
 
-  cookiesClearAll(): Chromeless<T> {
-    this.queue.enqueue({type: 'cookiesClearAll'})
+  cookiesClear(): Chromeless<T> {
+    this.queue.enqueue({type: 'cookiesClear'})
 
     return this
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -266,20 +266,20 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return this
   }
 
-  cookiesDelete(name: string, url: string): Chromeless<T> {
+  deleteCookies(name: string, url: string): Chromeless<T> {
     if (typeof name === 'undefined') {
       throw new Error('Cookie name should be defined.')
     }
     if (typeof url === 'undefined') {
       throw new Error('Cookie url should be defined.')
     }
-    this.queue.enqueue({type: 'cookiesDelete', name, url})
+    this.queue.enqueue({type: 'deleteCookies', name, url})
 
     return this
   }
 
-  cookiesClear(): Chromeless<T> {
-    this.queue.enqueue({type: 'cookiesClear'})
+  clearCookies(): Chromeless<T> {
+    this.queue.enqueue({type: 'clearCookies'})
 
     return this
   }

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -159,8 +159,14 @@ export default class LocalRuntime {
   }
 
   async cookiesClearAll(): Promise<void> {
-    await clearCookies(this.client)
-    this.log('Cookies cleared')
+    const { Network } = this.client
+    const canClearCookies = await Network.canClearBrowserCookies()
+    if (canClearCookies) {
+      await clearCookies(this.client)
+      this.log('Cookies cleared')
+    } else {
+      this.log('Cookies could not be cleared')
+    }
   }
 
   async press(keyCode: number, count?: number, modifiers?: any): Promise<void> {

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -14,6 +14,7 @@ import {
   scrollTo,
   press,
   clearCookies,
+  deleteCookie,
   getCookies,
   setCookies, getAllCookies, version,
 } from '../util'
@@ -57,8 +58,10 @@ export default class LocalRuntime {
         return this.press(command.keyCode, command.count, command.modifiers)
       case 'scrollTo':
         return this.scrollTo(command.x, command.y)
-      case 'cookiesClearAll':
-        return this.cookiesClearAll()
+      case 'cookiesDelete':
+        return this.cookiesDelete(command.name, command.url)
+      case 'cookiesClear':
+        return this.cookiesClear()
       case 'cookiesGet':
         return this.cookiesGet(command.nameOrQuery)
       case 'cookiesGetAll':
@@ -158,7 +161,18 @@ export default class LocalRuntime {
     throw new Error(`cookiesSet(): Invalid input ${nameOrCookies}, ${value}`)
   }
 
-  async cookiesClearAll(): Promise<void> {
+  async cookiesDelete(name: string, url: string): Promise<void> {
+    const { Network } = this.client
+    const canClearCookies = await Network.canClearBrowserCookies()
+    if (canClearCookies) {
+      await deleteCookie(this.client, name, url)
+      this.log(`Cookie ${name} cleared`)
+    } else {
+      this.log(`Cookie ${name} could not be cleared`)
+    }
+  }
+
+  async cookiesClear(): Promise<void> {
     const { Network } = this.client
     const canClearCookies = await Network.canClearBrowserCookies()
     if (canClearCookies) {

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -83,10 +83,10 @@ export default class LocalRuntime {
         return this.press(command.keyCode, command.count, command.modifiers)
       case 'scrollTo':
         return this.scrollTo(command.x, command.y)
-      case 'cookiesDelete':
-        return this.cookiesDelete(command.name, command.url)
-      case 'cookiesClear':
-        return this.cookiesClear()
+      case 'deleteCookies':
+        return this.deleteCookies(command.name, command.url)
+      case 'clearCookies':
+        return this.clearCookies()
       case 'setHtml':
         return this.setHtml(command.html)
       case 'cookiesGet':
@@ -280,7 +280,7 @@ export default class LocalRuntime {
     throw new Error(`cookiesSet(): Invalid input ${nameOrCookies}, ${value}`)
   }
 
-  async cookiesDelete(name: string, url: string): Promise<void> {
+  async deleteCookies(name: string, url: string): Promise<void> {
     const { Network } = this.client
     const canClearCookies = await Network.canClearBrowserCookies()
     if (canClearCookies) {
@@ -291,7 +291,7 @@ export default class LocalRuntime {
     }
   }
 
-  async cookiesClear(): Promise<void> {
+  async clearCookies(): Promise<void> {
     const { Network } = this.client
     const canClearCookies = await Network.canClearBrowserCookies()
     if (canClearCookies) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,10 +128,10 @@ export type Command =
       selector?: string
     }
   | {
-      type: 'cookiesClear'
+      type: 'clearCookies'
     }
   | {
-      type: 'cookiesDelete'
+      type: 'deleteCookies'
       name: string
       url: string
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,12 @@ export type Command =
       selector?: string
     }
   | {
-      type: 'cookiesClearAll'
+      type: 'cookiesClear'
+    }
+  | {
+      type: 'cookiesDelete'
+      name: string
+      url: string
     }
   | {
       type: 'cookiesSet'

--- a/src/util.ts
+++ b/src/util.ts
@@ -252,6 +252,12 @@ function getUrlFromCookie(cookie: Cookie) {
   return `https://${domain}`
 }
 
+export async function deleteCookie(client: Client, name: string, url: string): Promise<void> {
+  const {Network} = client
+
+  await Network.deleteCookie({cookieName: name, url})
+}
+
 export async function clearCookies(client: Client): Promise<void> {
   const {Network} = client
 


### PR DESCRIPTION
`cookiesClear` did not check if it could be executed, so added that check, but also rewrote the API names to make it more clear what both endpoints do(n't).