### PR TITLE
feat: query cookie by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,28 +7,33 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- CODE_OF_CONDUCT.md, CONTRIBUTING.md
+
 ### Changed
-- README improvements. @timsuchanek @adieuadieu @hax @Chrisgozd
+- `.evaluate()` now returns the resulting value or a Promise [#110](https://github.com/graphcool/chromeless/pull/110) @joelgriffith
+- README improvements. @timsuchanek @adieuadieu @hax @Chrisgozd @githubixx @d2s @vladgolubev
 
 ### Fixed
 - Ensure latest version of Serverless is used during deployment. [#58](https://github.com/graphcool/chromeless/issues/58)
 - package repository url [#64](https://github.com/graphcool/chromeless/pull/64) @Hazealign
 
 
-## [1.1.0] - 2017-07-27
+## [1.0.1] - 2017-07-27
 ### Added
-- CHANGELOG.md @adieuadieu
-- LICENSE file (MIT) @adieuadieu
+- CHANGELOG.md
+- LICENSE file (MIT)
 - `implicitWait`: By default wait for `.press` and `.click` for a cleaner workflow
 
 ### Changed
 - `.end()`: now returns the last value
 
 ### Fixed
-- The cookie commands did break the queue, now they work like expected
+- The cookie commands broke the queue, now they work like expected
 
 ### Changed
 - Many README improvements. @schickling @sorenbs @emeth- @timsuchanek @adieuadieu @toddwprice
+
 
 ## [1.0.0] - 2017-07-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CODE_OF_CONDUCT.md, CONTRIBUTING.md
 - `getHtml()` and `setHtml()` APIs. [#112](https://github.com/graphcool/chromeless/pull/112), [#74](https://github.com/graphcool/chromeless/issues/74)
 - `mousedown(selector: string): Chromeless<T>` and `mouseup(selector: string): Chromeless<T>` APIs [#118](https://github.com/graphcool/chromeless/pull/118) @criticalbh
+- `cookiesGet(name: string)` API @criticalbh
 
 ### Changed
 - `.evaluate()` now returns the resulting value or a Promise [#110](https://github.com/graphcool/chromeless/pull/110) @joelgriffith

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `.evaluate()` now returns the resulting value or a Promise [#110](https://github.com/graphcool/chromeless/pull/110) @joelgriffith
 - README improvements. @timsuchanek @adieuadieu @hax @Chrisgozd @githubixx @d2s @vladgolubev
+- `cookiesGet()` is now getter `cookies`
 
 ### Fixed
 - Ensure latest version of Serverless is used during deployment. [#58](https://github.com/graphcool/chromeless/issues/58)

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ const chromeless = new Chromeless({
 - [`screenshot()`](docs/api.md#api-screenshot)
 - [`pdf()`](docs/api.md#api-pdf) - Not implemented yet
 - [`getHtml()`](docs/api.md#api-gethtml)
-- [`cookiesGet()`](docs/api.md#api-cookiesget)
+- [`cookies`](docs/api.md#api-cookiesget)
 - [`cookiesGet(name: string)`](docs/api.md#api-cookiesget-name)
 - [`cookiesGet(query: CookieQuery)`](docs/api.md#api-cookiesget-query) - Not implemented yet
 - [`cookiesGetAll()`](docs/api.md#api-cookiesgetall)

--- a/docs/api.md
+++ b/docs/api.md
@@ -418,14 +418,14 @@ console.log(html) // <html><head></head><body><h1>Hello world!</h1></body></html
 
 <a name="api-cookiesget" />
 
-### cookiesGet(): Chromeless<Cookie[] | null>
+### get cookies(): Chromeless<Cookie[] | null>
 
 Returns all browser cookies for the current URL.
 
 __Example__
 
 ```js
-await chromeless.cookiesGet()
+await chromeless.cookies
 ```
 
 ---------------------------------------

--- a/src/api.ts
+++ b/src/api.ts
@@ -199,7 +199,7 @@ export default class Chromeless<T extends any> implements Promise<T> {
    */
   cookiesGet(query: CookieQuery): Chromeless<Cookie[] | null>
   cookiesGet(nameOrQuery?: string | CookieQuery): Chromeless<Cookie | Cookie[] | null> {
-    if (typeof nameOrQuery !== 'undefined') {
+    if (typeof nameOrQuery !== 'undefined' && typeof nameOrQuery !== 'string') {
       throw new Error('Querying cookies is not implemented yet')
     }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -187,25 +187,28 @@ export default class Chromeless<T extends any> implements Promise<T> {
   /**
    * Get the cookies for the current url
    */
-  cookiesGet(): Chromeless<Cookie[] | null>
+  get cookies(): Chromeless<Cookie[] | null> {
+    return this.cookiesGet(undefined)
+  }
+
   /**
    * Get a specific cookie for the current url
    * @param name
    */
-  cookiesGet(name: string): Chromeless<Cookie | null>
+  cookiesGet(name: string): Chromeless<Cookie[] | null>
   /**
    * Get a specific cookie by query. Not implemented yet
    * @param query
    */
   cookiesGet(query: CookieQuery): Chromeless<Cookie[] | null>
-  cookiesGet(nameOrQuery?: string | CookieQuery): Chromeless<Cookie | Cookie[] | null> {
+  cookiesGet(nameOrQuery?: string | CookieQuery): Chromeless<Cookie[] | null> {
     if (typeof nameOrQuery !== 'undefined' && typeof nameOrQuery !== 'string') {
       throw new Error('Querying cookies is not implemented yet')
     }
 
     this.lastReturnPromise = this.queue.process<Cookie[] | Cookie | null>({type: 'cookiesGet', nameOrQuery})
 
-    return new Chromeless<Cookie | Cookie[] | null>({}, this)
+    return new Chromeless<Cookie[] | null>({}, this)
   }
 
   cookiesGetAll(): Chromeless<Cookie[]> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -246,10 +246,6 @@ export async function setHtml(client: Client, html: string): Promise<void> {
 }
 
 export async function getCookies(client: Client, nameOrQuery?: string | Cookie): Promise<any> {
-  if (nameOrQuery) {
-    throw new Error('Not yet implemented')
-  }
-
   const {Network} = client
 
   const fn = () => location.href
@@ -257,7 +253,13 @@ export async function getCookies(client: Client, nameOrQuery?: string | Cookie):
   const url = await evaluate(client, `${fn}`) as string
 
   const result = await Network.getCookies([url])
-  return result.cookies
+  const cookies = result.cookies
+
+  if (typeof nameOrQuery !== 'undefined' && typeof nameOrQuery === 'string') {
+    const filter: Cookie[] = cookies.filter(cookie => cookie.name === nameOrQuery)
+    return filter
+  }
+  return cookies
 }
 
 export async function getAllCookies(client: Client): Promise<any> {


### PR DESCRIPTION
Hello,

Here is the implementation of get cookie by name.

I know that in the API spec `cookiesGet(name: string)` should return `Cookie | null` but in different paths it is possible to have same name so I implemented it to return `Cookie[] | null`. However I would like to hear opinions from you and make changes on this PR.

Thanks,
Admir