### PR TITLE
feat: focus dom element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CODE_OF_CONDUCT.md, CONTRIBUTING.md
 - `getHtml()` and `setHtml()` APIs. [#112](https://github.com/graphcool/chromeless/pull/112), [#74](https://github.com/graphcool/chromeless/issues/74)
 - `mousedown(selector: string): Chromeless<T>` and `mouseup(selector: string): Chromeless<T>` APIs [#118](https://github.com/graphcool/chromeless/pull/118) @criticalbh
+- `focus(selector: string)` API [#132](https://github.com/graphcool/chromeless/pull/132) @criticalbh
 
 ### Changed
 - `.evaluate()` now returns the resulting value or a Promise [#110](https://github.com/graphcool/chromeless/pull/110) @joelgriffith

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ const chromeless = new Chromeless({
 - [`wait(timeout: number)`](docs/api.md#api-wait-timeout)
 - [`wait(selector: string)`](docs/api.md#api-wait-selector)
 - [`wait(fn: (...args: any[]) => boolean, ...args: any[])`] - Not implemented yet
-- [`focus(selector: string)`](docs/api.md#api-focus) - Not implemented yet
+- [`focus(selector: string)`](docs/api.md#api-focus)
 - [`press(keyCode: number, count?: number, modifiers?: any)`](docs/api.md#api-press)
 - [`type(input: string, selector?: string)`](docs/api.md#api-type)
 - [`back()`](docs/api.md#api-back) - Not implemented yet

--- a/docs/api.md
+++ b/docs/api.md
@@ -146,8 +146,6 @@ await chromeless.wait(() => { return console.log('@TODO: put a better example he
 
 ### focus(selector: string): Chromeless<T>
 
-Not implemented yet
-
 Provide focus on a DOM element.
 
 __Arguments__

--- a/src/api.ts
+++ b/src/api.ts
@@ -97,7 +97,8 @@ export default class Chromeless<T extends any> implements Promise<T> {
   }
 
   focus(selector: string): Chromeless<T> {
-    throw new Error('Not implemented yet')
+      this.queue.enqueue({type: 'focus', selector})
+      return this
   }
 
   press(keyCode: number, count?: number, modifiers?: any): Chromeless<T> {

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -17,7 +17,7 @@ import {
   press,
   clearCookies,
   getCookies,
-  setCookies, getAllCookies, version, mousedown, mouseup
+  setCookies, getAllCookies, version, mousedown, mouseup, focus
 } from '../util'
 
 export default class LocalRuntime {
@@ -75,6 +75,8 @@ export default class LocalRuntime {
         return this.mousedown(command.selector)
       case 'mouseup':
         return this.mousup(command.selector)
+      case 'focus':
+        return this.focus(command.selector)
       default:
         throw new Error(`No such command: ${JSON.stringify(command)}`)
     }
@@ -158,6 +160,21 @@ export default class LocalRuntime {
 
   private async setHtml(html: string): Promise<void> {
     await setHtml(this.client, html)
+  }
+
+  private async focus(selector: string): Promise<void> {
+      if (this.chromlessOptions.implicitWait) {
+          this.log(`focus(): Waiting for ${selector}`)
+          await waitForNode(this.client, selector, this.chromlessOptions.waitTimeout)
+      }
+
+      const exists = await nodeExists(this.client, selector)
+      if (!exists) {
+          throw new Error(`focus(): node for selector ${selector} doesn't exist`)
+      }
+
+      await focus(this.client, selector)
+      this.log(`Focus on ${selector}`)
   }
 
   async type(text: string, selector?: string): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,10 @@ export type Command =
       type: 'mouseup',
       selector: string
     }
+  | {
+      type: 'focus',
+      selector: string
+    }
 
 export interface Cookie {
   url?: string

--- a/src/util.ts
+++ b/src/util.ts
@@ -119,15 +119,10 @@ export async function click(client: Client, selector: string, scale: number) {
 }
 
 export async function focus(client: Client, selector: string): Promise<void> {
-  const {Runtime} = client
-  const focus = (selector) => {
-    return document.querySelector(selector).focus()
-  }
-  const expression = `(${focus})(\`${selector}\`)`
-
-  await Runtime.evaluate({
-    expression,
-  })
+  const {DOM} = client
+  const dom = await DOM.getDocument()
+  const node = await DOM.querySelector({nodeId: dom.root.nodeId, selector: selector})
+  await DOM.focus(node)
 }
 
 export async function evaluate<T>(client: Client, fn: string, ...args: any[]): Promise<T> {


### PR DESCRIPTION
I have changed util `focus` method to https://chromedevtools.github.io/devtools-protocol/tot/DOM/#method-focus. If you prefer eval methods over this one I will change it.

However there is one small issue with combination of `focus` and `press`. Both implementations of `focus` dont work well with `press`. I dont know if that has something with my local environment.