### PR TITLE
TypeScript error with activated strictNullChecks compiler option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- chromeless can now be imported into TypeScript projects with activated `strictNullChecks` compiler option [#154](https://github.com/graphcool/chromeless/pull/154) @clebert
 
 
 ## [1.1.0] - 2017-08-02

--- a/src/api.ts
+++ b/src/api.ts
@@ -53,8 +53,8 @@ export default class Chromeless<T extends any> implements Promise<T> {
   readonly [Symbol.toStringTag]: 'Promise'
 
   then<U>(
-    onFulfill: (value: T) => U | PromiseLike<U>,
-    onReject?: (error: any) => U | PromiseLike<U>,
+    onFulfill?: ((value: T) => U | PromiseLike<U>) | null,
+    onReject?: ((error: any) => U | PromiseLike<U>) | null,
   ): Promise<U> {
     return this.lastReturnPromise.then(onFulfill, onReject) as Promise<U>
   }


### PR DESCRIPTION
If I import `chromeless` into my TypeScript project with activated `strictNullChecks` compiler option,
I get the following error: `Class 'Chromeless<T>' incorrectly implements interface 'Promise<T>'.`

This pull request fixes the error.