### PR TITLE
Use port from options instead of this.chromeInstance

### DIFF
--- a/src/chrome/local.ts
+++ b/src/chrome/local.ts
@@ -58,7 +58,7 @@ export default class LocalChrome implements Chrome {
       fitWindow: false, // as we cannot resize the window, `fitWindow: false` is needed in order for the viewport to be resizable
     }
 
-    const port = this.chromeInstance ? this.chromeInstance.port : 9222
+    const port = this.options.cdp.port
     const versionResult = await CDP.Version({ port })
     const isHeadless = versionResult['User-Agent'].includes('Headless')
 


### PR DESCRIPTION
Using a local chrome causes an error where this.chromeInstance is undefined.
this.chromeInstance is not set in connectToChrome and the port for the local chrome might be something else than 9222.

Closes #159 