### PR TITLE
Feat: Scroll to Element

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ const chromeless = new Chromeless({
 - [`refresh()`](docs/api.md#api-refresh) - Not implemented yet
 - [`mousedown(selector: string)`](docs/api.md#api-mousedown)
 - [`mouseup(selector: string)`](docs/api.md#api-mouseup)
-- [`scrollTo(x: number, y: number)`](docs/api.md#api-scrollto)
-- [`scrollToElement(selector: string)`](docs/api.md#api-scrolltoElement)
+- [`scrollTo(x: number, y: number)`](docs/api.md#api-scrollto-coordinates)
+- [`scrollTo(selector: string)`](docs/api.md#api-scrollto-selector)
 - [`setHtml(html: string)`](docs/api.md#api-sethtml)
 - [`viewport(width: number, height: number)`](docs/api.md#api-viewport)
 - [`evaluate<U extends any>(fn: (...args: any[]) => void, ...args: any[])`](docs/api.md#api-evaluate)

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ const chromeless = new Chromeless({
 - [`mousedown(selector: string)`](docs/api.md#api-mousedown)
 - [`mouseup(selector: string)`](docs/api.md#api-mouseup)
 - [`scrollTo(x: number, y: number)`](docs/api.md#api-scrollto)
+- [`scrollToElement(selector: string)`](docs/api.md#api-scrolltoElement)
 - [`setHtml(html: string)`](docs/api.md#api-sethtml)
 - [`viewport(width: number, height: number)`](docs/api.md#api-viewport)
 - [`evaluate<U extends any>(fn: (...args: any[]) => void, ...args: any[])`](docs/api.md#api-evaluate)

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,6 +21,7 @@ Chromeless provides TypeScript typings.
 - [`mousedown(selector: string)`](#api-mousedown)
 - [`mouseup(selector: string)`](#api-mouseup)
 - [`scrollTo(x: number, y: number)`](#api-scrollto)
+- [`scrollToElement(selector: string)`](#api-scrolltoElement)
 - [`setHtml(html: string)`](#api-sethtml)
 - [`viewport(width: number, height: number)`](#api-viewport)
 - [`evaluate<U extends any>(fn: (...args: any[]) => void, ...args: any[])`](#api-evaluate)
@@ -283,6 +284,23 @@ Scroll to somewhere in the document.
 __Arguments__
 - `x` - Offset from top of the document
 - `y` - Offset from the left of the document
+
+__Example__
+
+```js
+await chromeless.scrollTo(500, 0)
+```
+
+---------------------------------------
+
+<a name="api-scrolltoElement" />
+
+### scrollToElement(selectot: string): Chromeless<T>
+
+Scroll to an element in the document.
+
+__Arguments__
+- `selector` - DOM selector for element to send scrolltoElement event
 
 __Example__
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,8 +20,8 @@ Chromeless provides TypeScript typings.
 - [`refresh()`](#api-refresh) - Not implemented yet
 - [`mousedown(selector: string)`](#api-mousedown)
 - [`mouseup(selector: string)`](#api-mouseup)
-- [`scrollTo(x: number, y: number)`](#api-scrollto)
-- [`scrollToElement(selector: string)`](#api-scrolltoElement)
+- [`scrollTo(x: number, y: number)`](#api-scrollto-coordinates)
+- [`scrollTo(selector: string)`](#api-scrollto-selector)
 - [`setHtml(html: string)`](#api-sethtml)
 - [`viewport(width: number, height: number)`](#api-viewport)
 - [`evaluate<U extends any>(fn: (...args: any[]) => void, ...args: any[])`](#api-evaluate)
@@ -275,7 +275,7 @@ await chromeless.mouseup('#placeholder')
 
 ---------------------------------------
 
-<a name="api-scrollto" />
+<a name="api-scrollto-coordinates" />
 
 ### scrollTo(x: number, y: number): Chromeless<T>
 
@@ -293,19 +293,19 @@ await chromeless.scrollTo(500, 0)
 
 ---------------------------------------
 
-<a name="api-scrolltoElement" />
+<a name="api-scrollto-selector" />
 
-### scrollToElement(selectot: string): Chromeless<T>
+### scrollTo(selector: string): Chromeless<T>
 
 Scroll to an element in the document.
 
 __Arguments__
-- `selector` - DOM selector for element to send scrolltoElement event
+- `selector` - DOM selector for element to scroll to
 
 __Example__
 
 ```js
-await chromeless.scrollTo(500, 0)
+await chromeless.scrollTo('#placeholder')
 ```
 
 ---------------------------------------

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,7 @@
 import ChromeLocal from './chrome/local'
 import ChromeRemote from './chrome/remote'
 import Queue from './queue'
-import { Chrome, ChromelessOptions, Cookie, CookieQuery, PdfOptions } from './types'
+import { ChromelessOptions, Cookie, CookieQuery, PdfOptions } from './types'
 import { getDebugOption } from './util'
 
 export default class Chromeless<T extends any> implements Promise<T> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -148,14 +148,21 @@ export default class Chromeless<T extends any> implements Promise<T> {
     throw new Error('Not implemented yet')
   }
 
-  scrollTo(x: number, y: number): Chromeless<T> {
-    this.queue.enqueue({ type: 'scrollTo', x, y })
-
-    return this
-  }
-
-  scrollToElement(selector: string): Chromeless<T> {
-    this.queue.enqueue({ type: 'scrollToElement', selector })
+  scrollTo(x: number, y: number): Chromeless<T>
+  scrollTo(selector: string): Chromeless<T>
+  scrollTo(firstArg, ...args: any[]): Chromeless<T> {
+    switch (typeof firstArg) {
+      case 'number': {
+        this.queue.enqueue({ type: 'scrollTo', x: firstArg, y: args[0] })
+        break
+      }
+      case 'string': {
+        this.queue.enqueue({ type: 'scrollTo', selector: firstArg })
+        break
+      }
+      default:
+        throw new Error(`Invalid scrollTo arguments: ${firstArg} ${args}`)
+    }
 
     return this
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -157,7 +157,7 @@ export default class Chromeless<T extends any> implements Promise<T> {
         break
       }
       case 'string': {
-        this.queue.enqueue({ type: 'scrollTo', selector: firstArg})
+        this.queue.enqueue({ type: 'scrollTo', selector: firstArg })
         break
       }
       default:

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,7 @@
 import ChromeLocal from './chrome/local'
 import ChromeRemote from './chrome/remote'
 import Queue from './queue'
-import { ChromelessOptions, Cookie, CookieQuery, PdfOptions } from './types'
+import { Chrome, ChromelessOptions, Cookie, CookieQuery, PdfOptions } from './types'
 import { getDebugOption } from './util'
 
 export default class Chromeless<T extends any> implements Promise<T> {
@@ -150,6 +150,12 @@ export default class Chromeless<T extends any> implements Promise<T> {
 
   scrollTo(x: number, y: number): Chromeless<T> {
     this.queue.enqueue({ type: 'scrollTo', x, y })
+
+    return this
+  }
+
+  scrollToElement(selector: string): Chromeless<T> {
+    this.queue.enqueue({ type: 'scrollToElement', selector })
 
     return this
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -157,7 +157,7 @@ export default class Chromeless<T extends any> implements Promise<T> {
         break
       }
       case 'string': {
-        this.queue.enqueue({ type: 'scrollTo', selector: firstArg })
+        this.queue.enqueue({ type: 'scrollTo', selector: firstArg})
         break
       }
       default:

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -77,10 +77,15 @@ export default class LocalRuntime {
         return this.type(command.input, command.selector)
       case 'press':
         return this.press(command.keyCode, command.count, command.modifiers)
-      case 'scrollTo':
-        return this.scrollTo(command.x, command.y)
-      case 'scrollToElement':
-        return this.scrollToElement(command.selector)
+      case 'scrollTo': {
+        if (command.x, command.y) {
+          return this.scrollTo(command.x, command.y)
+        } else if (command.selector) {
+          return this.scrollToElement(command.selector)
+        } else {
+          throw new Error('scrollFn not yet implemented')
+        }
+      }
       case 'setHtml':
         return this.setHtml(command.html)
       case 'cookiesClearAll':

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -21,6 +21,7 @@ import {
   type,
   getValue,
   scrollTo,
+  scrollToElement,
   setHtml,
   press,
   clearCookies,
@@ -78,6 +79,8 @@ export default class LocalRuntime {
         return this.press(command.keyCode, command.count, command.modifiers)
       case 'scrollTo':
         return this.scrollTo(command.x, command.y)
+      case 'scrollToElement':
+        return this.scrollToElement(command.selector)
       case 'setHtml':
         return this.setHtml(command.html)
       case 'cookiesClearAll':
@@ -151,6 +154,11 @@ export default class LocalRuntime {
 
   private async scrollTo<T>(x: number, y: number): Promise<void> {
     return scrollTo(this.client, x, y)
+  }
+
+  private async scrollToElement<T>(selector: string): Promise<void> {
+    const { scale } = this.chromelessOptions.viewport
+    return scrollToElement(this.client, selector, scale)
   }
 
   private async mousedown(selector: string): Promise<void> {

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -167,7 +167,8 @@ export default class LocalRuntime {
   }
 
   private async scrollToElement<T>(selector: string): Promise<void> {
-    return scrollToElement(this.client, selector)
+    const { scale } = this.chromelessOptions.viewport
+    return scrollToElement(this.client, selector, scale)
   }
 
   private async mousedown(selector: string): Promise<void> {

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -162,8 +162,7 @@ export default class LocalRuntime {
   }
 
   private async scrollToElement<T>(selector: string): Promise<void> {
-    const { scale } = this.chromelessOptions.viewport
-    return scrollToElement(this.client, selector, scale)
+    return scrollToElement(this.client, selector)
   }
 
   private async mousedown(selector: string): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,10 @@ export type Command =
       y: number
     }
   | {
+      type: 'scrollToElement'
+      selector: string
+    }
+  | {
       type: 'setHtml'
       html: string
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,12 +91,9 @@ export type Command =
     }
   | {
       type: 'scrollTo'
-      x: number
-      y: number
-    }
-  | {
-      type: 'scrollToElement'
-      selector: string
+      x?: number
+      y?: number
+      selector?: string
     }
   | {
       type: 'setHtml'

--- a/src/util.ts
+++ b/src/util.ts
@@ -262,6 +262,26 @@ export async function scrollTo(
   })
 }
 
+export async function scrollToElement(
+    client: Client,
+    selector: string,
+    scale: number,
+): Promise<void> {
+    const clientRect = await getClientRect(client, selector)
+    const coordinates = {
+        x: Math.round((clientRect.left + clientRect.width / 2) * scale),
+        y: Math.round((clientRect.top + clientRect.height / 2) * scale)
+    }
+    const { Runtime } = client
+    const browserCode = (x, y) => {
+        return window.scrollTo(x, y)
+    }
+    const expression = `(${browserCode})(${coordinates.x}, ${coordinates.y})`
+    await Runtime.evaluate({
+        expression,
+    })
+}
+
 export async function setHtml(client: Client, html: string): Promise<void> {
   const { Page } = client
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -302,12 +302,13 @@ export async function scrollTo(
 
 export async function scrollToElement(
     client: Client,
-    selector: string
+    selector: string,
+    scale: number,
 ): Promise<void> {
     const clientRect = await getClientRect(client, selector)
     const coordinates = {
-        x: Math.round(clientRect.left),
-        y: Math.round(clientRect.top)
+        x: Math.round((clientRect.left + clientRect.width / 2) * scale),
+        y: Math.round((clientRect.top + clientRect.height / 2) * scale)
     }
     const { Runtime } = client
     const browserCode = (x, y) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -264,13 +264,12 @@ export async function scrollTo(
 
 export async function scrollToElement(
     client: Client,
-    selector: string,
-    scale: number,
+    selector: string
 ): Promise<void> {
     const clientRect = await getClientRect(client, selector)
     const coordinates = {
-        x: Math.round((clientRect.left + clientRect.width / 2) * scale),
-        y: Math.round((clientRect.top + clientRect.height / 2) * scale)
+        x: Math.round(clientRect.left),
+        y: Math.round(clientRect.top)
     }
     const { Runtime } = client
     const browserCode = (x, y) => {


### PR DESCRIPTION
This pull request adds an additional feature for the **'scrollTo'** method. This now gives you the ability to scroll to a selector as well as still supporting coordinates.

- Added documentation for the new api function.
- Added new switch to case statement for enabling both selector and coordinates.
- Added new 'scrollToElement' function within util.