### PR TITLE
Fix: Generating screenshots/pdf using os.tmpdir() for Windows

### DIFF
--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -9,6 +9,8 @@ import {
 } from '../types'
 import * as cuid from 'cuid'
 import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
 import {
   nodeExists,
   wait,
@@ -342,8 +344,8 @@ export default class LocalRuntime {
 
       return `https://${process.env['CHROMELESS_S3_BUCKET_URL']}/${s3Path}`
     } else {
-      // write to `/tmp` instead
-      const filePath = `/tmp/${cuid()}.png`
+      // write to `${os.tmpdir()}` instead
+      const filePath = path.join(os.tmpdir(), `${cuid()}.png`)
       fs.writeFileSync(filePath, Buffer.from(data, 'base64'))
 
       return filePath
@@ -377,8 +379,8 @@ export default class LocalRuntime {
 
       return `https://${process.env['CHROMELESS_S3_BUCKET_URL']}/${s3Path}`
     } else {
-      // write to `/tmp` instead
-      const filePath = `/tmp/${cuid()}.pdf`
+      // write to `${os.tmpdir()}` instead
+      const filePath = path.join(os.tmpdir(), `${cuid()}.pdf`)
       fs.writeFileSync(filePath, Buffer.from(data, 'base64'))
 
       return filePath

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,3 +1,4 @@
+import * as os from 'os'
 import test from 'ava'
 import Chromeless from '../src'
 
@@ -11,4 +12,24 @@ test('google title', async t => {
   await chromeless.end()
 
   t.is(title, 'Google')
+})
+
+test('screenshot and pdf path', async t => {
+  const chromeless = new Chromeless({ launchChrome: false })
+  const screenshot = await chromeless
+    .goto('https://www.google.com')
+    .screenshot()
+  const pdf = await chromeless
+    .goto('https://www.google.com')
+    .pdf()
+
+  await chromeless.end()
+
+  if (os.platform() === 'win32') {
+    t.regex(screenshot, /\\/)
+    t.regex(pdf, /\\/)
+  } else {
+    t.regex(screenshot, /tmp/)
+    t.regex(pdf, /tmp/)
+  }
 })


### PR DESCRIPTION
Since Windows does not use the temporary directory on `/tmp`, so the usage of `os.tmpdir()` is needed.