### PR TITLE
fix (proxy): correctly package dependencies in latest serverless@1.19.0

### DIFF
--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -46,25 +46,6 @@ plugins:
   - serverless-plugin-chrome
   - serverless-offline
 
-package:
-  exclude:
-    # - ./**
-    - node_modules/typescript/**
-    - node_modules/serverless-**/**
-    - node_modules/lighthouse**/**
-    - node_modules/devtools-timeline-model/**
-    - node_modules/chrome-devtools-frontend/**
-    - node_modules/uglify-js/**
-    # - node_modules/chromeless/**
-    # - '!node_modules/chromeless/dist/**'
-    # - '!node_modules/chromeless/package.json'
-  include:
-    - ./src/**.js
-    # - node_modules/chromeless/dist/**
-    # - node_modules/chromeless/package.json
-
-  excludeDevDependencies: false
-
 functions:
   run:
     memorySize: 1536


### PR DESCRIPTION
Fixes packaging excludes in the Proxy so that `chrome-launcher` dependencies are included in the deployment package. The excludeDevelopmentDependencies feature in Serverless seems to now correctly package dependencies.

Reported in https://github.com/graphcool/chromeless/issues/99#issuecomment-320076119