### PR TITLE
provide ability to listen to network events being made and received

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -302,6 +302,54 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return this
   }
 
+  requestWillBeSentEvent(func: void): Chromeless<T> {
+    this.queue.enqueue({type: 'requestWillBeSentEvent', func})
+
+    return this
+  }
+
+  requestSentEvent(func: void): Chromeless<T> {
+    this.queue.enqueue({type: 'requestSentEvent', func})
+
+    return this
+  }
+
+  responseReceivedEvent(func: void): Chromeless<T> {
+    this.queue.enqueue({type: 'responseReceivedEvent', func})
+
+    return this
+  }
+
+  requestServedFromCacheEvent(func: void): Chromeless<T> {
+    this.queue.enqueue({type: 'requestServedFromCacheEvent', func})
+
+    return this
+  }
+
+  dataReceivedEvent(func: void): Chromeless<T> {
+    this.queue.enqueue({type: 'dataReceivedEvent', func})
+
+    return this
+  }
+
+  loadingFinishedEvent(func: void): Chromeless<T> {
+    this.queue.enqueue({type: 'loadingFinishedEvent', func})
+
+    return this
+  }
+
+  loadingFailedEvent(func: void): Chromeless<T> {
+    this.queue.enqueue({type: 'loadingFailedEvent', func})
+
+    return this
+  }
+
+  requestInterceptedEvent(func: void): Chromeless<T> {
+    this.queue.enqueue({type: 'requestInterceptedEvent', func})
+
+    return this
+  }
+
   async end(): Promise<T> {
     const result = await this.lastReturnPromise
     await this.queue.end()

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -110,9 +110,75 @@ export default class LocalRuntime {
         return this.focus(command.selector)
       case 'clearInput':
         return this.clearInput(command.selector)
+      case 'requestWillBeSentEvent':
+        return this.requestWillBeSentEvent(command.func)
+      case 'requestSentEvent':
+        return this.requestSentEvent(command.func)
+      case 'dataReceivedEvent':
+        return this.dataReceivedEvent(command.func)
+      case 'requestServedFromCacheEvent':
+        return this.requestServedFromCacheEvent(command.func)
+      case 'dataReceivedEvent':
+        return this.dataReceivedEvent(command.func)
+      case 'loadingFinishedEvent':
+        return this.loadingFinishedEvent(command.func)
+      case 'loadingFailedEvent':
+        return this.loadingFailedEvent(command.func)
+      case 'requestInterceptedEvent':
+        return this.requestInterceptedEvent(command.func)
+      case 'responseReceivedEvent':
+        return this.responseReceivedEvent(command.func)
       default:
         throw new Error(`No such command: ${JSON.stringify(command)}`)
     }
+  }
+
+  private async requestWillBeSentEvent(func: void): Promise<void> {
+      const { Network } = this.client
+      Network.requestWillBeSent(func)
+      console.log('requestWillBeSent eventlistener added')
+  }
+
+  private async requestSentEvent(func: void): Promise<void> {
+    const { Network } = this.client
+    Network.requestSent(func)
+    console.log('requestSent eventlistener added')
+  }
+
+  private async dataReceivedEvent(func: void): Promise<void> {
+    const { Network } = this.client
+    Network.dataReceived(func)
+    console.log('dateReceived eventlistener added')
+  }
+
+  private async requestServedFromCacheEvent(func: void): Promise<void> {
+    const { Network } = this.client
+    Network.requestServedFromCache(func)
+    console.log('requestServedFromCache eventlistener added')
+  }
+
+  private async loadingFinishedEvent(func: void): Promise<void> {
+    const { Network } = this.client
+    Network.loadingFinished(func)
+    console.log('loadingFinished eventlistener added')
+  }
+
+  private async loadingFailedEvent(func: void): Promise<void> {
+    const { Network } = this.client
+    Network.loadingFailed(func)
+    console.log('loadingFailed eventlistener added')
+  }
+
+  private async requestInterceptedEvent(func: void): Promise<void> {
+    const { Network } = this.client
+    Network.requestIntercepted(func)
+    console.log('requestIntercepted eventlistener added')
+  }
+
+  private async responseReceivedEvent(func: void): Promise<void> {
+    const { Network } = this.client
+    Network.responseReceived(func)
+    console.log('responseReceived eventlistener added')
   }
 
   private async goto(url: string): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,38 @@ export type Command =
     type: 'clearInput'
     selector: string
   }
+  | {
+      type: 'requestWillBeSentEvent'
+      func: void
+    }
+  | {
+      type: 'requestSentEvent'
+      func: void
+  }
+  | {
+      type: 'dataReceivedEvent'
+      func: void
+    }
+  | {
+      type: 'requestServedFromCacheEvent'
+      func: void
+    }
+  | {
+      type: 'loadingFinishedEvent'
+      func: void
+  }
+  | {
+      type: 'loadingFailedEvent'
+      func: void
+  }
+  | {
+      type: 'requestInterceptedEvent'
+      func: void
+  }
+  | {
+      type: 'responseReceivedEvent'
+      func: void
+  }
 
 export interface Cookie {
   url?: string


### PR DESCRIPTION
To inspect if network requests are correct, you need the ability to listen to requests and its responses. This is fully possible by https://chromedevtools.github.io/devtools-protocol/tot/Network/ so I added the endpoints to be able to do:

```js
. responseReceivedEvent((response) => { console.log (response) })
```

and inspect the responses received with Chromeless.

I did not added documentation / websocket-endpoints to first get some feedback about this approach, while the steps described using Chromeless will trigger these events. 
I think this is the best approach, because you will be able to define listeners when they are needed or just track all network traffic. All headers are available to inspect like partly requested in #87 and #156 .

Could you provide feedback if this is the right way to add it and then I will add documentation, etc.
Later on we can discuss how to add `.stats()` and `.responses()` endpoints to provide the data without any manual steps like described above with `.responseReceivedEvent()`.
