### PR TITLE
Added clearStorage functionality 

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ const chromeless = new Chromeless({
 - [`wait(selector: string)`](docs/api.md#api-wait-selector)
 - [`wait(fn: (...args: any[]) => boolean, ...args: any[])`] - Not implemented yet
 - [`clearCache()`](docs/api.md#api-clearcache)
+- [`clearStorage(origin: string, storageTypes: string)`](docs/api.md#api-clearstorage)
 - [`focus(selector: string)`](docs/api.md#api-focus)
 - [`press(keyCode: number, count?: number, modifiers?: any)`](docs/api.md#api-press)
 - [`type(input: string, selector?: string)`](docs/api.md#api-type)

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,7 @@ Chromeless provides TypeScript typings.
 - [`wait(selector: string)`](#api-wait-selector)
 - [`wait(fn: (...args: any[]) => boolean, ...args: any[])`] - Not implemented yet
 - [`clearCache()`](docs/api.md#api-clearcache)
+- [`clearStorage(origin: string, storageTypes: string)`](docs/api.md#api-clearstorage)
 - [`focus(selector: string)`](#api-focus)
 - [`press(keyCode: number, count?: number, modifiers?: any)`](#api-press)
 - [`type(input: string, selector?: string)`](#api-type)
@@ -174,6 +175,27 @@ __Example__
 
 ```js
 await chromeless.clearCache()
+```
+
+---------------------------------------
+
+<a name="api-clearstorage" />
+
+### clearStorage(origin: string, storageTypes: string): Chromeless<T>
+
+Clears browser storage.
+
+__Arguments__
+- `origin` - Security origin for the storage type we wish to clear
+
+- `storageTypes` - A string comma separated list of chrome storage types. Allowed values include: appcache, cookies, file_systems, indexeddb, local_storage, shader_cache, websql, service_workers, cache_storage, all, other. More information at the [Chrome Devtools Protocol website](https://chromedevtools.github.io/devtools-protocol/tot/Storage/).
+
+__Example__
+
+```js
+await chromeless.clearStorage('http://localhost', 'local_storage, websql')
+
+await chromeless.clearStorage('*', 'all')
 ```
 
 ---------------------------------------

--- a/src/api.ts
+++ b/src/api.ts
@@ -119,6 +119,12 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return this
   }
 
+  clearStorage(origin: string, storageTypes: string): Chromeless<T> {
+    this.queue.enqueue({ type: 'clearStorage', origin, storageTypes })
+
+    return this
+  }
+
   focus(selector: string): Chromeless<T> {
     this.queue.enqueue({ type: 'focus', selector })
     return this

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -67,6 +67,8 @@ export default class LocalRuntime {
       }
       case 'clearCache':
         return this.clearCache()
+      case 'clearStorage':
+        return this.clearStorage(command.origin, command.storageTypes)
       case 'setUserAgent':
         return this.setUserAgent(command.useragent)
       case 'click':
@@ -136,6 +138,17 @@ export default class LocalRuntime {
       this.log(`Cache is cleared`)
     } else {
       this.log(`Cache could not be cleared`)
+    }
+  }
+
+  private async clearStorage(origin: string, storageTypes: string): Promise<void> {
+    const { Storage, Network } = this.client
+    const canClearCache = await Network.canClearBrowserCache
+    if (canClearCache) {
+      await Storage.clearDataForOrigin({origin, storageTypes})
+      this.log(`${storageTypes} for ${origin} is cleared`)
+    } else {
+      this.log(`${storageTypes} could not be cleared`)
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface Client {
   Input: any
   Runtime: any
   Emulation: any
+  Storage: any
   close: () => void
   target: {
     id: string
@@ -137,6 +138,11 @@ export type Command =
     }
   | {
       type: 'clearCookies'
+    }
+  | {
+      type: 'clearStorage'
+      origin: string
+      storageTypes: string
     }
   | {
       type: 'deleteCookies'


### PR DESCRIPTION
Added functionality to expose Storage.clearDataForOrigin
 as specified in https://chromedevtools.github.io/devtools-protocol/tot/Storage/ . This will allow the user to clear localstorage/websql etc.

For example:

await chromeless.clearStorage('http://localhost', 'local_storage, websql')

await chromeless.clearStorage('*', 'all')

