### PR TITLE
pass client host and port to remote interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface Client {
   target: {
     id: string
   }
+  host?: string
+  port?: number
 }
 
 export interface DeviceMetrics {

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,7 +24,7 @@ export async function setViewport(
     fitWindow: false, // as we cannot resize the window, `fitWindow: false` is needed in order for the viewport to be resizable
   }
 
-  const versionResult = await CDP.Version()
+  const versionResult = await CDP.Version({ port: client.port, host: client.host });
   const isHeadless = versionResult['User-Agent'].includes('Headless')
 
   if (viewport.height && viewport.width) {


### PR DESCRIPTION
when chrome is running on some other port than the default
chromeless was failing silently

```
(node:93065) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: connect ECONNREFUSED 127.0.0.1:9222
(node:93065) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:93065) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): Error: connect ECONNREFUSED 127.0.0.1:9222
```

