### PR TITLE
Fix "TypeError: Cannot read property 'slice' of undefined" when using `setCookies` API

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -352,10 +352,7 @@ export async function setCookies(
   const { Network } = client
 
   for (const cookie of cookies) {
-    await Network.setCookie({
-      ...cookie,
-      url: getUrlFromCookie(cookie),
-    })
+    await Network.setCookie(cookie)
   }
 }
 
@@ -395,11 +392,6 @@ export async function mouseup(client: Client, selector: string, scale: number) {
     ...options,
     type: 'mouseReleased',
   })
-}
-
-function getUrlFromCookie(cookie: Cookie) {
-  const domain = cookie.domain.slice(1, cookie.domain.length)
-  return `https://${domain}`
 }
 
 export async function deleteCookie(


### PR DESCRIPTION
Version: chromeless@1.2.0

Example code:

```js
const { Chromeless } = require('chromeless');

async function run() {
  const chromeless = new Chromeless();

  const result = await chromeless
    .goto('https://httpbin.org/cookies')
    .setCookies('name1', 'val2')
    .html();

  console.log(result);

  await chromeless.end();
}

run().catch(error => console.error(error) || process.exit(1));
```

Result:

```js
TypeError: Cannot read property 'slice' of undefined
    at getUrlFromCookie (/Users/archielee/Repository/aaa/node_modules/chromeless/dist/src/util.js:582:31)
    at Object.<anonymous> (/Users/archielee/Repository/aaa/node_modules/chromeless/dist/src/util.js:520:88)
    at step (/Users/archielee/Repository/aaa/node_modules/chromeless/dist/src/util.js:40:23)
    at Object.next (/Users/archielee/Repository/aaa/node_modules/chromeless/dist/src/util.js:21:53)
    at /Users/archielee/Repository/aaa/node_modules/chromeless/dist/src/util.js:15:71
    at Promise (<anonymous>)
    at __awaiter (/Users/archielee/Repository/aaa/node_modules/chromeless/dist/src/util.js:11:12)
    at Object.setCookies (/Users/archielee/Repository/aaa/node_modules/chromeless/dist/src/util.js:509:12)
    at LocalRuntime.<anonymous> (/Users/archielee/Repository/aaa/node_modules/chromeless/dist/src/chrome/local-runtime.js:454:53)
    at step (/Users/archielee/Repository/aaa/node_modules/chromeless/dist/src/chrome/local-runtime.js:32:23)
```
