### PR TITLE
Fix unhandled rejection

### DIFF
--- a/src/chrome/local.ts
+++ b/src/chrome/local.ts
@@ -39,7 +39,10 @@ export default class LocalChrome implements Chrome {
       logLevel: this.options.debug ? 'info' : 'silent',
       port: this.options.cdp.port,
     })
-    return await CDP({ port: this.chromeInstance.port })
+    const target = await CDP.New({
+      port: this.chromeInstance.port,
+    })
+    return await CDP({ target })
   }
 
   private async connectToChrome(): Promise<Client> {
@@ -99,7 +102,7 @@ export default class LocalChrome implements Chrome {
     const { client } = await this.runtimeClientPromise
 
     if (this.options.cdp.closeTab) {
-      CDP.Close({ id: client.target.id })
+      await CDP.Close({ id: client.target.id })
     }
 
     if (this.chromeInstance) {


### PR DESCRIPTION
By making sure we're passing the right target to newly launched chrome
instance and later into the CDP.Close(...) call

Closes #187