### PR TITLE
add chromeFlags to Chromeless constructor

### DIFF
--- a/src/chrome/local.ts
+++ b/src/chrome/local.ts
@@ -38,6 +38,7 @@ export default class LocalChrome implements Chrome {
     this.chromeInstance = await launch({
       logLevel: this.options.debug ? 'info' : 'silent',
       port: this.options.cdp.port,
+      chromeFlags: this.options.chromeFlags,
     })
     return await CDP({ port: this.chromeInstance.port })
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export interface ChromelessOptions {
   launchChrome?: boolean // auto-launch chrome (local) `true`
   cdp?: CDPOptions
   remote?: RemoteOptions | boolean
+  chromeFlags?: any[]
 }
 
 export interface Chrome {


### PR DESCRIPTION
Example:
```
const chromeless = new Chromeless({ 
	debug: true, 
	port: PORT,
	chromeFlags: [
		'--window-size=1366,786',
		'--proxy-server=myproxy.com:3128',
		'--disable-gpu',
		'--headless',
	]
});
```