### PR TITLE
Update api.md - fix scrollTo API docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -299,13 +299,13 @@ await chromeless.mouseup('#placeholder')
 Scroll to somewhere in the document.
 
 __Arguments__
-- `x` - Offset from top of the document
-- `y` - Offset from the left of the document
+- `x` - Offset from the left of the document
+- `y` - Offset from the top of the document
 
 __Example__
 
 ```js
-await chromeless.scrollTo(500, 0)
+await chromeless.scrollTo(0, 500)
 ```
 
 ---------------------------------------


### PR DESCRIPTION
You have the offset parameters the wrong way around in the docs.