### PR TITLE
allow key prefix for all s3 images, configured via environment

### DIFF
--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -62,7 +62,7 @@ functions:
             - "-"
             - Ref: AWS::Region
             - -chromeless
-      CHROMELESS_S3_BUCKET_KEY_PREFIX: ""
+      CHROMELESS_S3_OBJECT_KEY_PREFIX: ""
       CHROMELESS_S3_BUCKET_URL:
         Fn::GetAtt:
           - Bucket

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -62,6 +62,7 @@ functions:
             - "-"
             - Ref: AWS::Region
             - -chromeless
+      CHROMELESS_S3_BUCKET_KEY_PREFIX: ""
       CHROMELESS_S3_BUCKET_URL:
         Fn::GetAtt:
           - Bucket

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -364,7 +364,8 @@ export default class LocalRuntime {
       process.env['CHROMELESS_S3_BUCKET_NAME'] &&
       process.env['CHROMELESS_S3_BUCKET_URL']
     ) {
-      const s3Path = `${cuid()}.png`
+      const prefix = process.env['CHROMELESS_S3_BUCKET_KEY_PREFIX'] || ''
+      const s3Path = `${prefix}${cuid()}.png`
       const s3 = new AWS.S3()
       await s3
         .putObject({

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -364,7 +364,7 @@ export default class LocalRuntime {
       process.env['CHROMELESS_S3_BUCKET_NAME'] &&
       process.env['CHROMELESS_S3_BUCKET_URL']
     ) {
-      const prefix = process.env['CHROMELESS_S3_BUCKET_KEY_PREFIX'] || ''
+      const prefix = process.env['CHROMELESS_S3_OBJECT_KEY_PREFIX'] || ''
       const s3Path = `${prefix}${cuid()}.png`
       const s3 = new AWS.S3()
       await s3


### PR DESCRIPTION
![celebrate](https://onewebstrategy.files.wordpress.com/2012/07/celebrate.gif)

The number of s3 buckets is limited per account in s3.  As such, a common pattern is to use a single bucket and prefix the keys for s3 objects per app, etc.  This PR enables key prefixing.