### PR TITLE
Html Saved on S3 With URL Returned Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- It's now possible to specify an S3 object key prefix in with a `CHROMELESS_S3_OBJECT_KEY_PREFIX` environment variable [#224](https://github.com/graphcool/chromeless/pull/224) @pklingem
+- A parameter to specify `waitTimeout` when waiting for a seletor with `wait(selector, waitTimeout)` [#212](https://github.com/graphcool/chromeless/pull/212), [#208](https://github.com/graphcool/chromeless/issues/208) @janza
 
 ### Changed
 
 ### Fixed
 - Mistakes in `scrollTo` parameters API documentation [#220](https://github.com/graphcool/chromeless/pull/220) @okeeffed
 - Typo in mocha/chai example [#218](https://github.com/graphcool/chromeless/pull/218) @sul4bh
+- Fixed unhandled promise rejection error in `chromeless.end()` [#213](https://github.com/graphcool/chromeless/pull/213), [#187](https://github.com/graphcool/chromeless/issues/187) @janza
 
 ## [1.2.0] - 2017-08-06
 
@@ -23,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `setFileInput()` API method [#100](https://github.com/graphcool/chromeless/issues/100), [#170](https://github.com/graphcool/chromeless/pull/170) @criticalbh
 - `clearCache()` API method [#122](https://github.com/graphcool/chromeless/pull/122) @joeyvandijk
 - `scrollToElement()` command and `scrollBeforeClick` constructor option [#15](https://github.com/graphcool/chromeless/issues/15), [#167](https://github.com/graphcool/chromeless/pull/167) @janza
-- `cookies(name: string)` API method [#183](https://github.com/graphcool/chromeless/pull/183/files) @criticalbh
+- `cookies(name: string)` API method [#183](https://github.com/graphcool/chromeless/pull/183) @criticalbh
 - Mocha E2E tests [example](examples/mocha-chai-test-example.js) [#164](https://github.com/graphcool/chromeless/pull/164) @FabioAntunes
 
 ### Changed

--- a/src/api.ts
+++ b/src/api.ts
@@ -231,6 +231,15 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return new Chromeless<string>({}, this)
   }
 
+  htmlUrl(): Chromeless<string> {
+    this.lastReturnPromise = this.queue.process<string>({
+      type: 'returnHtmlUrl'
+    })
+
+    return new Chromeless<string>({}, this)
+  }
+
+
   pdf(options?: PdfOptions): Chromeless<string> {
     this.lastReturnPromise = this.queue.process<string>({
       type: 'returnPdf',

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -413,7 +413,7 @@ export default class LocalRuntime {
           Key: s3Path,
           ContentType: 'text/html',
           ACL: 'public-read',
-          Body: new Buffer(data, 'base64'),
+          Body: new Buffer(data, 'utf-8'),
         })
         .promise()
 
@@ -421,7 +421,7 @@ export default class LocalRuntime {
     } else {
       // write to `${os.tmpdir()}` instead
       const filePath = path.join(os.tmpdir(), `${cuid()}.html`)
-      fs.writeFileSync(filePath, Buffer.from(data, 'base64'))
+      fs.writeFileSync(filePath, Buffer.from(data, 'utf-8'))
 
       return filePath
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,9 @@ export type Command =
       type: 'returnHtml'
     }
   | {
+      type: 'returnHtmlUrl'
+    }
+  | {
       type: 'returnPdf'
       options?: PdfOptions
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -434,6 +434,15 @@ export async function html(client: Client): Promise<string> {
   return outerHTML
 }
 
+export async function htmlUrl(client: Client): Promise<string> {
+  const { DOM } = client
+
+  const { root: { nodeId } } = await DOM.getDocument()
+  const { outerHTML } = await DOM.getOuterHTML({ nodeId })
+  return outerHTML
+}
+
+
 export async function pdf(
   client: Client,
   options?: PdfOptions,


### PR DESCRIPTION
This endpoint created solves an issue with 128Kb limit for AWS IoT not being able to return back an html string larger than that size via the `.html()` endpoint as discussed here: https://github.com/graphcool/chromeless/issues/114