### PR TITLE
Interduce setEmulateMedia so that we can emulate print css for example

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -181,6 +181,12 @@ export default class Chromeless<T extends any> implements Promise<T> {
     return this
   }
 
+  setEmulatedMedia(mediaType : 'screen' | 'print' | null): Chromeless<T> {
+    this.queue.enqueue({ type: 'setEmulatedMedia', mediaType })
+
+    return this
+  }
+
   setHtml(html: string): Chromeless<T> {
     this.queue.enqueue({ type: 'setHtml', html })
 

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -23,6 +23,7 @@ import {
   setHtml,
   press,
   setViewport,
+  setEmulateMedia,
   clearCookies,
   deleteCookie,
   getCookies,
@@ -55,6 +56,8 @@ export default class LocalRuntime {
         return this.goto(command.url)
       case 'setViewport':
         return setViewport(this.client, command.options)
+      case 'setEmulatedMedia':
+        return setEmulateMedia(this.client, command.mediaType)
       case 'wait': {
         if (command.selector) {
           return this.waitSelector(command.selector, command.timeout)

--- a/src/chrome/local.ts
+++ b/src/chrome/local.ts
@@ -38,6 +38,7 @@ export default class LocalChrome implements Chrome {
     this.chromeInstance = await launch({
       logLevel: this.options.debug ? 'info' : 'silent',
       port: this.options.cdp.port,
+      chromeFlags : this.options.chromeFlags
     })
     const target = await CDP.New({
       port: this.chromeInstance.port,

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,10 @@ export interface Chrome {
 }
 
 export type Command =
+  |{
+    type:'setEmulatedMedia'
+    mediaType : 'screen' | 'print' | null
+  }
   | {
       type: 'goto'
       url: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export interface ChromelessOptions {
   launchChrome?: boolean // auto-launch chrome (local) `true`
   cdp?: CDPOptions
   remote?: RemoteOptions | boolean
+  chromeFlags? : string[]
 }
 
 export interface Chrome {

--- a/src/util.ts
+++ b/src/util.ts
@@ -53,6 +53,13 @@ export async function setViewport(
   return
 }
 
+export async function setEmulateMedia(
+    client: Client,
+    mediaType: "screen" | "print" | null
+): Promise<void> {
+    await client.Emulation.setEmulatedMedia({ media: mediaType || "" });
+}
+
 export async function waitForNode(
   client: Client,
   selector: string,


### PR DESCRIPTION
Also add a way to send parameters to chrome launcher (we need it to be able to run headless-ly and with extensions enabled for some scenarios.
For example, in order to create a pdf with setEmulatedMedia("print") we will create chromeless like this:
```
const chromeless = new Chromeless({chromeFlags:[
        // Disable built-in Google Translate service
        '--disable-translate',
        // Disable all chrome extensions entirely
        //'--disable-extensions',
        // Disable various background network services, including extension updating,
        //   safe browsing service, upgrade detector, translate, UMA
        '--disable-background-networking',
        // Disable fetching safebrowsing lists, likely redundant due to disable-background-networking
        '--safebrowsing-disable-auto-update',
        // Disable syncing to a Google account
        '--disable-sync',
        // Disable reporting to UMA, but allows for collection
        '--metrics-recording-only',
        // Disable installation of default apps on first run
        '--disable-default-apps',
        // Mute any audio
        '--mute-audio',
        // Skip first run wizards
        '--no-first-run',
        '--headless',
      ]
    })
```