### PR TITLE
Enable chromeFlags and customize userDataDir

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -45,6 +45,7 @@ export default class Chromeless<T extends any> implements Promise<T> {
         closeTab: true,
         ...options.cdp,
       },
+      chromeFlags: ['--headless'],
     }
 
     const chrome = mergedOptions.remote

--- a/src/api.ts
+++ b/src/api.ts
@@ -45,7 +45,8 @@ export default class Chromeless<T extends any> implements Promise<T> {
         closeTab: true,
         ...options.cdp,
       },
-      chromeFlags: ['--headless'],
+      chromeFlags: [],
+      userDataDir: undefined
     }
 
     const chrome = mergedOptions.remote

--- a/src/api.ts
+++ b/src/api.ts
@@ -30,6 +30,8 @@ export default class Chromeless<T extends any> implements Promise<T> {
       implicitWait: true,
       scrollBeforeClick: false,
       launchChrome: true,
+      chromeFlags: [],
+      userDataDir: undefined,
 
       ...options,
 
@@ -45,8 +47,6 @@ export default class Chromeless<T extends any> implements Promise<T> {
         closeTab: true,
         ...options.cdp,
       },
-      chromeFlags: [],
-      userDataDir: undefined
     }
 
     const chrome = mergedOptions.remote

--- a/src/chrome/local.ts
+++ b/src/chrome/local.ts
@@ -38,6 +38,8 @@ export default class LocalChrome implements Chrome {
     this.chromeInstance = await launch({
       logLevel: this.options.debug ? 'info' : 'silent',
       port: this.options.cdp.port,
+      chromeFlags: this.options.chromeFlags,
+      chromePath: this.options.chromePath,
     })
     const target = await CDP.New({
       port: this.chromeInstance.port,

--- a/src/chrome/local.ts
+++ b/src/chrome/local.ts
@@ -40,6 +40,7 @@ export default class LocalChrome implements Chrome {
       port: this.options.cdp.port,
       chromeFlags: this.options.chromeFlags,
       chromePath: this.options.chromePath,
+      userDataDir: this.options.userDataDir
     })
     const target = await CDP.New({
       port: this.chromeInstance.port,

--- a/src/chrome/local.ts
+++ b/src/chrome/local.ts
@@ -35,25 +35,27 @@ export default class LocalChrome implements Chrome {
   }
 
   private async startChrome(): Promise<Client> {
+    const { port } = this.options.cdp
     this.chromeInstance = await launch({
       logLevel: this.options.debug ? 'info' : 'silent',
-      port: this.options.cdp.port,
+      port,
       chromeFlags: this.options.chromeFlags,
       chromePath: this.options.chromePath,
       userDataDir: this.options.userDataDir
     })
     const target = await CDP.New({
-      port: this.chromeInstance.port,
+      port,
     })
-    return await CDP({ target })
+    return await CDP({ target, port })
   }
 
   private async connectToChrome(): Promise<Client> {
+    const { host, port } = this.options.cdp
     const target = await CDP.New({
-      port: this.options.cdp.port,
-      host: this.options.cdp.host,
+      port,
+      host,
     })
-    return await CDP({ target })
+    return await CDP({ target, host, port })
   }
 
   private async setViewport(client: Client) {
@@ -66,8 +68,8 @@ export default class LocalChrome implements Chrome {
       fitWindow: false, // as we cannot resize the window, `fitWindow: false` is needed in order for the viewport to be resizable
     }
 
-    const port = this.options.cdp.port
-    const versionResult = await CDP.Version({ port })
+    const { host, port } = this.options.cdp
+    const versionResult = await CDP.Version({ host, port })
     const isHeadless = versionResult['User-Agent'].includes('Headless')
 
     if (viewport.height && viewport.width) {
@@ -105,7 +107,8 @@ export default class LocalChrome implements Chrome {
     const { client } = await this.runtimeClientPromise
 
     if (this.options.cdp.closeTab) {
-      await CDP.Close({ id: client.target.id })
+      const { host, port } = this.options.cdp
+      await CDP.Close({ host, port, id: client.target.id })
     }
 
     if (this.chromeInstance) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface Client {
   target: {
     id: string
   }
+  port: any
+  host: any
 }
 
 export interface DeviceMetrics {

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,8 @@ export interface ChromelessOptions {
   launchChrome?: boolean // auto-launch chrome (local) `true`
   cdp?: CDPOptions
   remote?: RemoteOptions | boolean
+  chromeFlags?: Array<string> // ['--headless']
+  chromePath?: string
 }
 
 export interface Chrome {

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface ChromelessOptions {
   remote?: RemoteOptions | boolean
   chromeFlags?: Array<string> // ['--headless']
   chromePath?: string
+  userDataDir?: string
 }
 
 export interface Chrome {

--- a/src/util.ts
+++ b/src/util.ts
@@ -27,7 +27,8 @@ export async function setViewport(
     fitWindow: false, // as we cannot resize the window, `fitWindow: false` is needed in order for the viewport to be resizable
   }
 
-  const versionResult = await CDP.Version()
+  const { host, port } = client
+  const versionResult = await CDP.Version({ host, port })
   const isHeadless = versionResult['User-Agent'].includes('Headless')
 
   if (viewport.height && viewport.width) {


### PR DESCRIPTION
This PR fixes https://github.com/graphcool/chromeless/pull/192 which added the _chromeFlags_ option but wasn't functional because of a misuse of the JS spread operator (user's custom settings were automatically ignored).

Also, it adds a new option _userDataDir_, which is the user profile's path. Useful if you want to keep separate user profiles.

Apart from the many possibilities _chromeFlags_ provides, there's the ability to set a proxy programatically:

`chromeFlags: ['--proxy-server=127.0.0.1:8082']`