### PR TITLE
Implement a fix to clear out the old queue so users can catch errors

### DIFF
--- a/src/queue.ts
+++ b/src/queue.ts
@@ -40,7 +40,14 @@ export default class Queue {
       this.lastWaitAll = this.waitAll()
     }
 
-    await this.lastWaitAll
+    const currentWaitAll = this.lastWaitAll
+    try {
+      await this.lastWaitAll      
+    } finally {
+      if (this.lastWaitAll == currentWaitAll) {
+        this.lastWaitAll = null;
+      }
+    }
 
     return this.chrome.process<T>(command)
   }

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -63,3 +63,19 @@ test('screenshot by selector', async t => {
     t.is(png.width, versionMajor > 60 ? 512 : 1440)
     t.is(png.height, versionMajor > 60 ? 512 : 900)
 })
+
+test('queue allows actions after an error', async t => {
+  const chromeless = new Chromeless({ launchChrome: false })
+  const error = await chromeless
+    .goto(testUrl)
+    .wait('.non-existant-selector', 100)
+    .screenshot()
+    .catch(error => error)
+
+  await error
+
+  const screenshot = await chromeless.screenshot();
+  
+  const regex = new RegExp(os.tmpdir().replace(/\\/g, '\\\\'))
+  t.regex(screenshot, regex)
+})


### PR DESCRIPTION
Fixes #279 : Not sure if this is necessarily the best way to fix this, but it fixed my problem & also the test I added.

The goal here is to allow chromeless.screenshot() (and other commands) to run after a failed command.

Example use case is in the test.

Note: When I ran npm:test on my machine nothing passed either before or after the edits, might want to add some additional docs, not sure exactly what's going on there. Running the tests using npm run watch:test worked all right, though one of the tests didn't pass because I wasn't running chrome headless.

