### PR TITLE
Add more screenshot options (format, quality and base64)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -447,6 +447,9 @@ __Arguments__
 - `selector` - DOM element to take a screenshot of,
 - `options` - An options object with the following props
 - `options.filePath` - A file path override in case of working locally
+- `options.format` - Image compression format (defaults to png). Allowed values: jpeg, png 
+- `options.quality` - Compression quality from range [0..100] (jpeg only)
+- `options.base64` - Whether to return a base64 string (defaults to returning a URL or local file path to the screenshot image)
 
 __Examples__
 
@@ -472,6 +475,18 @@ const screenshot = await chromeless
   .screenshot({ filePath: path.join(__dirname, 'google-search.png') })
 
 console.log(screenshot) // prints local file path or S3 URL
+```
+
+```js
+const screenshot = await chromeless
+  .goto('https://google.com/')
+  .screenshot({
+    format: 'jpeg',
+    quality: 40,
+    base64: true
+  })
+
+console.log(screenshot) // prints a base64 string for a jpeg image with compression quality set to 40
 ```
 
 ---------------------------------------

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -380,7 +380,11 @@ export default class LocalRuntime {
       }
     }
 
-    const data = await screenshot(this.client, selector)
+    const data = await screenshot(this.client, selector, options)
+
+    if (options && options.base64) {
+      return data
+    }
 
     if (isS3Configured()) {
       return await uploadToS3(data, 'image/png')

--- a/src/types.ts
+++ b/src/types.ts
@@ -221,6 +221,9 @@ export interface PdfOptions {
 
 export interface ScreenshotOptions {
   filePath?: string
+  quality?: number
+  format?: string
+  base64?: boolean
 }
 
 export type Quad = Array<number>

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,15 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 import * as cuid from 'cuid'
-import { Client, Cookie, DeviceMetrics, PdfOptions, BoxModel, Viewport } from './types'
+import {
+  Client,
+  Cookie,
+  DeviceMetrics,
+  PdfOptions,
+  BoxModel,
+  Viewport,
+  ScreenshotOptions,
+} from './types'
 import * as CDP from 'chrome-remote-interface'
 import * as AWS from 'aws-sdk'
 
@@ -450,13 +458,25 @@ export function boxModelToViewPort(model: BoxModel, scale: number): Viewport {
 export async function screenshot(
   client: Client,
   selector: string,
+  options: ScreenshotOptions,
 ): Promise<string> {
   const { Page } = client
 
-  const captureScreenshotOptions = {
-    format: 'png',
+  const captureScreenshotOptions: {
+    format: string
+    fromSurface: boolean
+    clip?: Object
+    quality?: number
+  } = {
+    format: 'png' || options.format,
     fromSurface: true,
     clip: undefined,
+    quality: undefined,
+  }
+
+  if (options && options.quality !== undefined) {
+    captureScreenshotOptions.format = 'jpeg'
+    captureScreenshotOptions.quality = typeof options.quality === 'string' ? parseInt(options.quality, 10) : options.quality
   }
 
   if (selector) {


### PR DESCRIPTION
Add possibility to specify the quality of the screenshots and filetype of the screenshots and whether to return a base64 string or store it.