### PR TITLE
Fix a small syntax error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Alternatively you can configure the Proxy service's endpoint with environment va
 ```js
 const chromeless = new Chromeless({
   remote: {
-    endpointUrl: 'https://XXXXXXXXXX.execute-api.eu-west-1.amazonaws.com/dev'
-    apiKey: 'your-api-key-here'
+    endpointUrl: 'https://XXXXXXXXXX.execute-api.eu-west-1.amazonaws.com/dev',
+    apiKey: 'your-api-key-here',
   },
 })
 ```

--- a/serverless/README.md
+++ b/serverless/README.md
@@ -126,8 +126,8 @@ const chromeless = new Chromeless({
 ```js
 const chromeless = new Chromeless({
   remote: {
-    endpointUrl: 'https://XXXXXXXXXX.execute-api.eu-west-1.amazonaws.com/dev'
-    apiKey: 'your-api-key-here'
+    endpointUrl: 'https://XXXXXXXXXX.execute-api.eu-west-1.amazonaws.com/dev',
+    apiKey: 'your-api-key-here',
   },
 })
 ```


### PR DESCRIPTION
Just noticed this when copy/pasting the remote config chunk into a project.