### PR TITLE
https://github.com/graphcool/chromeless/issues/332

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
   },
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "engines": {
     "node": ">= 6.10.0"
   },
   "scripts": {
-    "ava": "tsc -d && nyc ava",
-    "build": "npm run clean && tsc -d",
+    "ava": "tsc -d && cp package.json ./dist/package.json && nyc ava",
+    "build": "npm run clean && tsc -d && cp package.json ./dist/package.json",
     "clean": "rimraf dist",
     "coverage": "npm run ava",
     "precommit": "lint-staged",

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,13 +7,7 @@ import * as CDP from 'chrome-remote-interface'
 import * as AWS from 'aws-sdk'
 
 export const version: string = ((): string => {
-  if (fs.existsSync(path.join(__dirname, '../package.json'))) {
-    // development (look in /src)
     return require('../package.json').version
-  } else {
-    // production (look in /dist/src)
-    return require('../../package.json').version
-  }
 })()
 
 export async function setViewport(


### PR DESCRIPTION
Added copying the package.json to the dist directory part of the build and ava scripts and modified the version function since ../package.json  will always be a valid path now. 

PS: I'm not very confident about this change. I know it has resolved my specific issue but I'm not sure if there are other side-effects I haven't considered. 