### PR TITLE
Add support to specify s3 filenames for screenshots

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -229,10 +229,14 @@ export default class Chromeless<T extends any> implements Promise<T> {
     selector?: string,
     options?: ScreenshotOptions,
   ): Chromeless<string> {
-    if (typeof selector === 'object') {
-      options = selector
-      selector = undefined
-    }
+    // I am not sure why this code was here; it seems to be causing a bug
+    // where options can not be passed correctly (any options passed will be 
+    // seen as a selector)
+    //
+    //if (typeof selector === 'object') {
+    //  options = selector
+    //  selector = undefined
+    //}
     this.lastReturnPromise = this.queue.process<string>({
       type: 'returnScreenshot',
       selector,

--- a/src/chrome/local-runtime.ts
+++ b/src/chrome/local-runtime.ts
@@ -391,7 +391,7 @@ export default class LocalRuntime {
     const data = await screenshot(this.client, selector)
 
     if (isS3Configured()) {
-      return await uploadToS3(data, 'image/png')
+      return await uploadToS3(data, 'image/png', options && options.s3ObjectKeyPrefixOverride)
     } else {
       return writeToFile(data, 'png', options && options.filePath)
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,6 +227,7 @@ export interface PdfOptions {
 
 export interface ScreenshotOptions {
   filePath?: string
+  s3ObjectKeyPrefixOverride?: string //string to use as key when saving screenshots to s3
 }
 
 export type Quad = Array<number>

--- a/src/util.ts
+++ b/src/util.ts
@@ -595,12 +595,13 @@ const s3ContentTypes = {
   },
 }
 
-export async function uploadToS3(data: string, contentType: string): Promise<string> {
+export async function uploadToS3(data: string, contentType: string, s3ObjectKeyPrefixOverride?: string): Promise<string> {
   const s3ContentType = s3ContentTypes[contentType]
   if (!s3ContentType) {
     throw new Error(`Unknown S3 Content type ${contentType}`)
-  }
-  const s3Path = `${getS3ObjectKeyPrefix()}${cuid()}.${s3ContentType.extension}`
+  }  
+  const s3Prefix = s3ObjectKeyPrefixOverride || `${getS3ObjectKeyPrefix()}`
+  const s3Path = `${s3Prefix}${cuid()}.${s3ContentType.extension}`
   const s3 = new AWS.S3()
   await s3
         .putObject({


### PR DESCRIPTION
This will allow for setting filenames from test code explicitly and dynamically, rather than statically via env variables.
.