### PR TITLE
Align env variables for ACL (file permissions)

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -605,7 +605,7 @@ function getS3ObjectKeyPrefix() {
 }
 
 function getS3FilesPermissions() {
-  return process.env['CHROMELESS_S3_FILES_PERMISSIONS'] || 'public-read'
+  return process.env['CHROMELESS_S3_OBJECT_ACL'] || 'public-read'
 }
 
 export function isS3Configured() {


### PR DESCRIPTION
The PR for adding file permissions configuration (https://github.com/graphcool/chromeless/pull/330) had a bug where the environment variable names weren't the same.

This aligns them to be `CHROMELESS_S3_OBJECT_ACL`.
