### PR TITLE
use type inference for evaluate

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -205,7 +205,7 @@ export default class Chromeless<T extends any> implements Promise<T> {
   }
 
   evaluate<U extends any>(
-    fn: (...args: any[]) => void,
+    fn: (...args: any[]) => U,
     ...args: any[]
   ): Chromeless<U> {
     this.lastReturnPromise = this.queue.process<U>({


### PR DESCRIPTION
Allows type inference for generic type `U` of `evaluate`.

There may be a reason I'm missing that it doesn't already work this way that I'm missing, but it seems useful to me.

Before:
![image](https://user-images.githubusercontent.com/15040698/37009060-2bc1d7fa-20b3-11e8-8af4-95a965597ea9.png)

After:
![image](https://user-images.githubusercontent.com/15040698/37009087-49032bfc-20b3-11e8-9435-9e82964a8c9c.png)

- [x] ~If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)~
- [x] ~Make sure all of the significant new logic is covered by tests~
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] ~If you've changed APIs, update the documentation in [README](/) and [/api/README](/api/README.md)~
